### PR TITLE
chore: request is now mandatory prop createWithCache (2024.10)

### DIFF
--- a/packages/hydrogen/src/weaverse-client.ts
+++ b/packages/hydrogen/src/weaverse-client.ts
@@ -57,7 +57,7 @@ export class WeaverseClient {
     this.cache = cache
     this.waitUntil = waitUntil
     this.countries = countries
-    this.withCache = createWithCache({ cache, waitUntil })
+    this.withCache = createWithCache({ cache, waitUntil, request })
 
     this.configs = getWeaverseConfigs(request, env as HydrogenEnv)
 


### PR DESCRIPTION
### Fix: Update `createWithCache` to Include Mandatory `request` Prop

#### Summary

This PR resolves a compatibility issue with the latest Hydrogen version (2024.10). Due to a breaking change, users are unable to update to version 2024.10 without encountering an error related to `createWithCache`.

#### Issue

When users attempt to upgrade using:

```bash
h2 upgrade --version 2024.10.0
```

they encounter the following error:

```
Theme settings load failed. TypeError: this.withCache is not a function
at WeaverseClient.fetchWithCache
...
```

#### Root Cause

In the previous version, `request` was an optional prop for `createWithCache`. As of version 2024.10, `request` has become mandatory during initialization. This change affects how we instantiate `createWithCache`, as omitting `request` will cause the function to throw a `TypeError`.

For additional details on this breaking change, refer to the release notes:
[Hydrogen Release Notes (2024.10.0)](https://github.com/Shopify/hydrogen/releases/tag/skeleton%402024.10.0).

#### Solution

This PR updates the instantiation of `createWithCache` to include the `request` prop, ensuring compatibility with Hydrogen version 2024.10.

#### Testing

- [X] Verified that `createWithCache` functions correctly with the `request` prop included.
- [X] Ensured that no other components are affected by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced caching logic to utilize request context for improved data management.
  
- **Bug Fixes**
	- Improved error handling in data fetching, providing clearer error messages that include response status and text for better debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->