### PR TITLE
Fix useChildInstances returning undefined

### DIFF
--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -30,7 +30,7 @@ export let useChildInstances = (id?: string) => {
   let {
     data: { children },
   } = currentInstance
-  return children.map(({ id }: { id: string }) => {
-    return itemInstances.get(id)
-  }) as WeaverseItemStore[]
+  return children
+    .map(({ id }: { id: string }) => itemInstances.get(id))
+    .filter(Boolean) as WeaverseItemStore[]
 }


### PR DESCRIPTION
## Summary
- filter out undefined results in `useChildInstances`

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb7f0a2bc832db0061918673df745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability by ensuring only valid child instances are returned in certain components, preventing potential issues caused by missing or invalid items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->