### PR TITLE
Fix CLI instruction path

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -192,7 +192,9 @@ Options:
             spinner.succeed('Dependencies installed successfully')
             console.log(chalk.green('\n🎉 Project created successfully!'))
             console.log(chalk.blue('\nNext steps:'))
-            console.log(chalk.gray(`1. cd ${argv['project-name']}`))
+            console.log(
+              chalk.gray(`1. cd ${toKebabCase(argv['project-name'])}`),
+            )
             console.log(
               chalk.gray('2. Pull your Shopify environment variables:'),
             )
@@ -217,7 +219,7 @@ Options:
         } else {
           console.log(chalk.green('\n🎉 Project created successfully!'))
           console.log(chalk.blue('\nNext steps:'))
-          console.log(chalk.gray(`1. cd ${argv['project-name']}`))
+          console.log(chalk.gray(`1. cd ${toKebabCase(argv['project-name'])}`))
           console.log(chalk.gray('2. Pull your Shopify environment variables:'))
           console.log(chalk.gray('   npx shopify hydrogen env pull'))
           console.log(chalk.gray('3. npm install'))


### PR DESCRIPTION
## Summary
- ensure CLI instructions display the kebab-case folder name

## Testing
- `npm test` *(fails: turbo not found)*
- `npm run biome` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbaf93c00832d8c9c8f4d4b4d31e0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated CLI instructions to display the project folder name in kebab-case, ensuring consistency with the actual folder name created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->