### PR TITLE
Release v5.1.0 via changesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [5.1.0] - 2025-06-04
+
+### Added
+- Support for the new `settings` property in component and theme schemas.
+
+### Changed
+- Deprecated the old `inspector` property. Schemas should now use `settings`.
+
+### Migration
+- Refer to the updated documentation for guidance on migrating existing
+  components from `inspector` to `settings`.
+
 ## [5.0.0] - 2025-05-27
 
 ### 🚀 MAJOR RELEASE: React Router v7 Migration

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @weaverse/core
 
+## 5.1.0
+
+### Minor Changes
+
+- Migrate `inspector` field to new `settings` property.
+
 ## 5.0.0
 
 ### Major Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@weaverse/core",
   "author": "Weaverse Team",
   "description": "Weaverse Core",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @weaverse/hydrogen
 
+## 5.1.0
+
+### Minor Changes
+
+- Migrate `inspector` field to new `settings` property.
+
+### Patch Changes
+
+- Updated dependencies
+  - @weaverse/react@5.1.0
+
 ## 5.0.0
 
 ### Major Changes

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -2,7 +2,7 @@
   "name": "@weaverse/hydrogen",
   "author": "Weaverse Team",
   "description": "Components, hooks, and utilities for building Shopify Hydrogen websites with Weaverse",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@shopify/hydrogen": ">=2025.5",
     "@shopify/remix-oxygen": "3",
-    "@weaverse/react": "5.0.0",
+    "@weaverse/react": "5.1.0",
     "react": ">=18",
     "react-dom": ">=18",
     "react-error-boundary": "^6",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @weaverse/react
 
+## 5.1.0
+
+### Minor Changes
+
+- Migrate `inspector` field to new `settings` property.
+
+### Patch Changes
+
+- Updated dependencies
+  - @weaverse/core@5.1.0
+
 ## 5.0.0
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
   "name": "@weaverse/react",
   "author": "Weaverse Team",
   "description": "React bindings for Weaverse",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -40,7 +40,7 @@
     "outDir": "dist"
   },
   "dependencies": {
-    "@weaverse/core": "5.0.0",
+    "@weaverse/core": "5.1.0",
     "clsx": "^2.1.1",
     "react": ">=18",
     "react-dom": ">=18"

--- a/packages/shopify/CHANGELOG.md
+++ b/packages/shopify/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @weaverse/shopify
 
+## 5.1.0
+
+### Minor Changes
+
+- Migrate `inspector` field to new `settings` property.
+
+### Patch Changes
+
+- Updated dependencies
+  - @weaverse/react@5.1.0
+
 ## 5.0.0
 
 ### Patch Changes

--- a/packages/shopify/package.json
+++ b/packages/shopify/package.json
@@ -2,7 +2,7 @@
   "name": "@weaverse/shopify",
   "author": "Weaverse Team",
   "description": "Weaverse Components for Shopify Online Store 2.0 Section builder",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -46,7 +46,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.1",
     "@stitches/react": "^1.2.8",
-    "@weaverse/react": "5.0.0",
+    "@weaverse/react": "5.1.0",
     "keen-slider": "^6.8.6"
   }
 }


### PR DESCRIPTION
## Summary
- document `inspector` to `settings` migration in changelog
- run changesets to bump packages to v5.1.0

## Testing
- `npm run typecheck` *(fails: turbo not found)*
- `npm run ci` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbcbebae4832d8067dbe10469955b