### PR TITLE
fix(hydrogen): route-scope WeaverseHydrogenRoot weaverseData lookup (#451)

### DIFF
--- a/.claude/skills/releasing-weaverse-sdks/SKILL.md
+++ b/.claude/skills/releasing-weaverse-sdks/SKILL.md
@@ -12,7 +12,7 @@ Release ritual for the `@weaverse/*` npm packages monorepo. Covers version bump,
 ## Context
 
 - **Public npm packages** under `@weaverse/*` scope
-- **Package manager:** `bun` only for development (never `npm install`)
+- **Package manager:** `pnpm` only for development (never `npm install` or `bun install`)
 - **Publish command:** `npm publish` (from individual package directories)
 - **Fixed version group:** core, react, hydrogen (always same version)
 - **Independent packages:** schema, cli, biome, i18n (each has own version)
@@ -100,7 +100,7 @@ Apply the semver bump:
 ### Step 4: Run Verification
 
 ```bash
-bun run biome && bun run typecheck && bun run test
+pnpm run biome && pnpm run typecheck && pnpm run test
 ```
 
 Always runs across ALL packages regardless of release scope. All three MUST pass. Do not proceed if any fail.
@@ -118,15 +118,15 @@ For each target package, edit `package.json`:
 ### Step 6: Update Lockfile
 
 ```bash
-bun install
+pnpm install
 ```
 
-This regenerates the lockfile to reflect the new version strings.
+This regenerates `pnpm-lock.yaml` to reflect the new version strings.
 
 ### Step 7: Build All Packages
 
 ```bash
-bun run build
+pnpm run build
 ```
 
 Turbo builds in dependency order (core → react → hydrogen). Must succeed. Building after the version bump ensures any embedded version strings are correct.
@@ -135,15 +135,15 @@ Turbo builds in dependency order (core → react → hydrogen). Must succeed. Bu
 
 ```bash
 # Fixed group
-git add packages/*/package.json bun.lock
+git add packages/*/package.json pnpm-lock.yaml
 git commit -m "release: v$NEW_VERSION (core, react, hydrogen)"
 
 # Independent package
-git add packages/$PKG/package.json bun.lock
+git add packages/$PKG/package.json pnpm-lock.yaml
 git commit -m "release: @weaverse/$PKG@$NEW_VERSION"
 ```
 
-Only stage `package.json` files and lockfile. Never use `git add -A`. Lefthook pre-commit hooks will run biome on staged files — this is expected and should pass.
+Only stage `package.json` files and `pnpm-lock.yaml`. Never use `git add -A`. Lefthook pre-commit hooks will run biome on staged files — this is expected and should pass.
 
 ### Step 9: Publish to npm
 
@@ -240,7 +240,7 @@ If publish partially succeeds (e.g., core publishes but react fails):
 
 ```
 parse intent → main + latest → npm auth (if not set) → calc versions (confirm) →
-verify (biome+types+tests) → bump versions → bun install → build →
+verify (biome+types+tests) → bump versions → pnpm install → build →
 commit → publish to npm (per-package) → tag → push → gh release → sync dev → verify npm
 ```
 
@@ -248,7 +248,7 @@ commit → publish to npm (per-package) → tag → push → gh release → sync
 
 | Mistake | Fix |
 |---------|-----|
-| Running `npm install` instead of `bun install` | This project uses bun only |
+| Running `npm install` or `bun install` instead of `pnpm install` | This project uses pnpm only (see `pnpm-lock.yaml` + `pnpm-workspace.yaml`) |
 | Publishing without npm auth configured | Run `npm config set //registry.npmjs.org/:_authToken YOUR_TOKEN` once |
 | Publishing without building first | Build must succeed before publish |
 | Forgetting internal dep updates | Fixed group packages reference each other — update the exact pins |
@@ -256,4 +256,4 @@ commit → publish to npm (per-package) → tag → push → gh release → sync
 | Not verifying npm registry after publish | Always check `npm view` to confirm |
 | Hardcoding version numbers | Always read from package.json and compute |
 | Mixing fixed + independent in one release | Run separate rituals for each scope |
-| Using `git add -A` for release commit | Only stage package.json files and bun.lock |
+| Using `git add -A` for release commit | Only stage `package.json` files and `pnpm-lock.yaml` |

--- a/packages/hydrogen/__tests__/pick-weaverse-data.test.ts
+++ b/packages/hydrogen/__tests__/pick-weaverse-data.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest'
+import { pickWeaverseData } from '../src/utils/pick-weaverse-data'
+
+// Minimal shape compatible with UIMatch['loaderData']; the helper only reads it.
+type Match = { loaderData: unknown }
+
+const layoutData = { page: { id: 'help-layout' } } as any
+const childData = { page: { id: 'help-contact' } } as any
+const otherData = { page: { id: 'other' } } as any
+
+describe('pickWeaverseData', () => {
+  describe('Tier 1: explicit data prop', () => {
+    it('returns explicit prop when provided', () => {
+      const matches: Match[] = [{ loaderData: { weaverseData: otherData } }]
+      const ownLoaderData = { weaverseData: otherData }
+
+      expect(pickWeaverseData(layoutData, ownLoaderData, matches)).toBe(
+        layoutData
+      )
+    })
+
+    it('returns explicit null prop (suppresses rendering)', () => {
+      const matches: Match[] = [{ loaderData: { weaverseData: otherData } }]
+      const ownLoaderData = { weaverseData: otherData }
+
+      expect(pickWeaverseData(null, ownLoaderData, matches)).toBeNull()
+    })
+
+    it('returns explicit Promise prop and does not unwrap', () => {
+      const pending = Promise.resolve(layoutData)
+      const matches: Match[] = [{ loaderData: { weaverseData: otherData } }]
+
+      const result = pickWeaverseData(pending, undefined, matches)
+
+      expect(result).toBe(pending)
+    })
+
+    it('falls through to next tier when prop is undefined', () => {
+      const matches: Match[] = []
+      const ownLoaderData = { weaverseData: layoutData }
+
+      expect(pickWeaverseData(undefined, ownLoaderData, matches)).toBe(
+        layoutData
+      )
+    })
+  })
+
+  describe('Tier 2: own route loader data (route-scoped primitive)', () => {
+    it('returns own route weaverseData when present', () => {
+      const matches: Match[] = [
+        { loaderData: { weaverseData: layoutData } },
+        { loaderData: { weaverseData: childData } },
+      ]
+      const ownLoaderData = { weaverseData: layoutData }
+
+      // This is the issue #451 case: a layout instance must NOT receive the
+      // child's data even though the child appears deeper in matches.
+      expect(pickWeaverseData(undefined, ownLoaderData, matches)).toBe(
+        layoutData
+      )
+    })
+
+    it('returns Promise weaverseData unchanged when own loader defers it', () => {
+      const pending = Promise.resolve(childData)
+      const ownLoaderData = { weaverseData: pending }
+
+      expect(pickWeaverseData(undefined, ownLoaderData, [])).toBe(pending)
+    })
+
+    it('ignores own loader data when it has no weaverseData key', () => {
+      const matches: Match[] = [{ loaderData: { weaverseData: layoutData } }]
+      const ownLoaderData = { shop: { name: 'Acme' } }
+
+      // Falls through to Tier 3 ancestor walk.
+      expect(pickWeaverseData(undefined, ownLoaderData, matches)).toBe(
+        layoutData
+      )
+    })
+
+    it('ignores non-object own loader data', () => {
+      const matches: Match[] = [{ loaderData: { weaverseData: layoutData } }]
+
+      expect(pickWeaverseData(undefined, null, matches)).toBe(layoutData)
+      expect(pickWeaverseData(undefined, undefined, matches)).toBe(layoutData)
+      expect(pickWeaverseData(undefined, 'string', matches)).toBe(layoutData)
+      expect(pickWeaverseData(undefined, 42, matches)).toBe(layoutData)
+    })
+  })
+
+  describe('Tier 3: ancestor matches walk (legacy fallback)', () => {
+    it('returns deepest ancestor with weaverseData when own has none', () => {
+      const matches: Match[] = [
+        { loaderData: { weaverseData: layoutData } },
+        { loaderData: { weaverseData: childData } },
+      ]
+
+      // Own loader data has no weaverseData → walk matches leaf → root.
+      // Deepest (childData) wins, preserving v5.x.x behaviour for the
+      // index-route-without-loader case the issue calls out.
+      expect(pickWeaverseData(undefined, {}, matches)).toBe(childData)
+    })
+
+    it('skips matches whose loaderData lacks weaverseData', () => {
+      const matches: Match[] = [
+        { loaderData: { weaverseData: layoutData } },
+        { loaderData: { shop: { name: 'Acme' } } }, // no weaverseData
+        { loaderData: null },
+      ]
+
+      expect(pickWeaverseData(undefined, undefined, matches)).toBe(layoutData)
+    })
+
+    it('returns null when no match has weaverseData', () => {
+      const matches: Match[] = [
+        { loaderData: { shop: { name: 'Acme' } } },
+        { loaderData: undefined },
+        { loaderData: null },
+      ]
+
+      expect(pickWeaverseData(undefined, undefined, matches)).toBeNull()
+    })
+
+    it('returns null for empty matches with no own data', () => {
+      expect(pickWeaverseData(undefined, undefined, [])).toBeNull()
+    })
+  })
+
+  describe('back-compat: unmodified pilot themes (zero-prop WeaverseContent)', () => {
+    it('canonical pilot route: loader returns { weaverseData }, default renders <WeaverseContent />', () => {
+      // Simulates an older pilot route module exactly as it ships today:
+      //   export async function loader() { return { weaverseData } }
+      //   export default () => <WeaverseContent />   // no `data` prop
+      // WeaverseHydrogenRoot then calls pickWeaverseData(undefined, ownLoaderData, matches).
+      const ownLoaderData = { weaverseData: childData }
+      // useMatches() returns [root, currentRoute] in framework mode; both may
+      // expose weaverseData (root usually doesn't). The single route case:
+      const matches: Match[] = [{ loaderData: ownLoaderData }]
+
+      expect(pickWeaverseData(undefined, ownLoaderData, matches)).toBe(
+        childData
+      )
+    })
+
+    it('canonical pilot route with extra root match: still resolves to own route', () => {
+      // Real Hydrogen apps always have a root route in the matches array,
+      // typically returning shop/cart/etc. but NOT weaverseData.
+      const ownLoaderData = { weaverseData: childData }
+      const matches: Match[] = [
+        { loaderData: { shop: { name: 'Pilot' }, cart: null } }, // root
+        { loaderData: ownLoaderData }, // current route
+      ]
+
+      expect(pickWeaverseData(undefined, ownLoaderData, matches)).toBe(
+        childData
+      )
+    })
+
+    it('legacy index-without-loader: list.tsx renders inside layout, layout provides weaverseData', () => {
+      // Pre-fix behaviour the issue explicitly preserves: an index/leaf route
+      // that has no loader (or a loader that omits weaverseData) falls back
+      // to its layout's data via the ancestor walk. This pattern is in active
+      // use (e.g. policies/list.tsx, collections/list.tsx in pilot variants).
+      const matches: Match[] = [
+        { loaderData: { shop: { name: 'Pilot' } } }, // root
+        { loaderData: { weaverseData: layoutData } }, // layout
+        { loaderData: {} }, // leaf index, no weaverseData
+      ]
+      const ownLoaderData = {} // leaf is the rendering route
+
+      expect(pickWeaverseData(undefined, ownLoaderData, matches)).toBe(
+        layoutData
+      )
+    })
+
+    it('legacy deferred loader: Promise weaverseData still flows through unchanged', () => {
+      const pending = Promise.resolve(childData)
+      const ownLoaderData = { weaverseData: pending }
+
+      expect(
+        pickWeaverseData(undefined, ownLoaderData, [
+          { loaderData: ownLoaderData },
+        ])
+      ).toBe(pending)
+    })
+
+    it('legacy missing weaverseData: returns null so errorComponent renders', () => {
+      // Mirrors the existing "No Weaverse data found in route matches!"
+      // error path from WeaverseHydrogenRoot.
+      const matches: Match[] = [
+        { loaderData: { shop: { name: 'Pilot' } } },
+        { loaderData: { someOtherKey: 1 } },
+      ]
+
+      expect(pickWeaverseData(undefined, {}, matches)).toBeNull()
+    })
+  })
+
+  describe('issue #451 regression: layout + child compose correctly', () => {
+    it('layout instance resolves to layout page; child instance resolves to child page', () => {
+      // Same matches array (useMatches is tree-global); each instance has its
+      // own loaderData via useLoaderData(). The two instances must diverge.
+      const matches: Match[] = [
+        { loaderData: { weaverseData: layoutData } },
+        { loaderData: { weaverseData: childData } },
+      ]
+
+      const layoutInstance = pickWeaverseData(
+        undefined,
+        { weaverseData: layoutData },
+        matches
+      )
+      const childInstance = pickWeaverseData(
+        undefined,
+        { weaverseData: childData },
+        matches
+      )
+
+      expect(layoutInstance).toBe(layoutData)
+      expect(childInstance).toBe(childData)
+      expect(layoutInstance).not.toBe(childInstance)
+    })
+  })
+})

--- a/packages/hydrogen/__tests__/pick-weaverse-data.test.ts
+++ b/packages/hydrogen/__tests__/pick-weaverse-data.test.ts
@@ -77,6 +77,25 @@ describe('pickWeaverseData', () => {
       )
     })
 
+    it('falls through to Tier 3 when own loader data has weaverseData: undefined', () => {
+      // Regression: `in` operator returns true for `{ weaverseData: undefined }`,
+      // which would let Tier 2 short-circuit and return undefined, bypassing
+      // the ancestor walk. The helper must treat `undefined` as absent.
+      const matches: Match[] = [{ loaderData: { weaverseData: layoutData } }]
+      const ownLoaderData = { weaverseData: undefined }
+
+      expect(pickWeaverseData(undefined, ownLoaderData, matches)).toBe(
+        layoutData
+      )
+    })
+
+    it('returns null when own loader has weaverseData: undefined and no ancestor has data', () => {
+      const matches: Match[] = [{ loaderData: { weaverseData: undefined } }]
+      const ownLoaderData = { weaverseData: undefined }
+
+      expect(pickWeaverseData(undefined, ownLoaderData, matches)).toBeNull()
+    })
+
     it('ignores non-object own loader data', () => {
       const matches: Match[] = [{ loaderData: { weaverseData: layoutData } }]
 
@@ -105,6 +124,16 @@ describe('pickWeaverseData', () => {
         { loaderData: { weaverseData: layoutData } },
         { loaderData: { shop: { name: 'Acme' } } }, // no weaverseData
         { loaderData: null },
+      ]
+
+      expect(pickWeaverseData(undefined, undefined, matches)).toBe(layoutData)
+    })
+
+    it('skips matches with weaverseData: undefined', () => {
+      // Same regression as Tier 2: `in` check alone would falsely match.
+      const matches: Match[] = [
+        { loaderData: { weaverseData: layoutData } },
+        { loaderData: { weaverseData: undefined } }, // present-but-undefined
       ]
 
       expect(pickWeaverseData(undefined, undefined, matches)).toBe(layoutData)

--- a/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
+++ b/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
@@ -419,6 +419,14 @@ export const WeaverseHydrogenRoot = memo(
       [dataProp, ownLoaderData, matches]
     )
 
+    // Explicit `data={null}` is the documented signal for "suppress rendering"
+    // (e.g. a route conditionally disables Weaverse without unmounting the
+    // component). This is distinct from auto-resolution returning `null`,
+    // which means "data was expected but not found" — the error path below.
+    if (dataProp === null) {
+      return null
+    }
+
     if (weaverseData) {
       if (weaverseData instanceof Promise) {
         return (

--- a/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
+++ b/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
@@ -15,7 +15,12 @@ import {
   useRef,
 } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import { Await, useMatches, useRouteLoaderData } from 'react-router'
+import {
+  Await,
+  useLoaderData,
+  useMatches,
+  useRouteLoaderData,
+} from 'react-router'
 import { defaultComponents } from '~/components'
 import {
   ThemeTextProvider,
@@ -41,6 +46,10 @@ import type {
 } from './types'
 import { hasWeaverseStudio } from './types'
 import { generateDataFromSchema } from './utils'
+import {
+  pickWeaverseData,
+  type WeaverseDataValue,
+} from './utils/pick-weaverse-data'
 import { ThemeTextStore } from './utils/theme-text-store'
 import { useStudio } from './utils/use-studio'
 import {
@@ -371,6 +380,7 @@ export function registerComponent(element: HydrogenElement) {
 export const WeaverseHydrogenRoot = memo(
   ({
     components,
+    data: dataProp,
     errorComponent: ErrorComponent = ({ error }) => (
       <div>
         {error instanceof Error
@@ -380,31 +390,34 @@ export const WeaverseHydrogenRoot = memo(
     ),
   }: {
     components: HydrogenComponent[]
+    /**
+     * Optional explicit `weaverseData` payload. When provided, bypasses the
+     * automatic route-scoped resolution. Accepts a resolved value, a
+     * `Promise` (handled via `<Await>`), or `null` to suppress rendering.
+     *
+     * Recommended for nested layout + child route compositions where two
+     * `<WeaverseHydrogenRoot>` instances need to render different Weaverse
+     * pages on the same URL. See issue #451.
+     */
+    data?: WeaverseDataValue
     errorComponent?: React.FC<{ error: Error | unknown }>
   }) => {
     const matches = useMatches()
 
-    // Create flat route-keyed data context from matches only
-    // No more useLoaderData dependency - everything comes from matches
+    // Flat route-keyed data context for data-connector template resolution
+    // (e.g. {{root.layout.shop.name}}). Legitimately needs all matches.
     const enhancedDataContext = createWeaverseDataContext(matches)
 
-    // Find weaverseData from matches - optimized with useMemo and reverse iteration
-    // Most recent route match (deepest in hierarchy) is most likely to have weaverseData
-    const weaverseData = useMemo(() => {
-      // Iterate backwards for better performance (most recent match first)
-      for (let i = matches.length - 1; i >= 0; i--) {
-        const match = matches[i]
-        const loaderData = match.loaderData as
-          | Record<string, unknown>
-          | undefined
-        if (loaderData && 'weaverseData' in loaderData) {
-          return loaderData.weaverseData as
-            | WeaverseLoaderData
-            | Promise<WeaverseLoaderData>
-        }
-      }
-      return null
-    }, [matches])
+    // Route-scoped weaverseData lookup. `useLoaderData()` returns the
+    // closest route's loader data, which is what makes nested layout +
+    // child routes work — each <WeaverseHydrogenRoot> instance resolves
+    // to its own route's weaverseData. See pickWeaverseData() for the
+    // three-tier fallback policy.
+    const ownLoaderData = useLoaderData() as unknown
+    const weaverseData = useMemo(
+      () => pickWeaverseData(dataProp, ownLoaderData, matches),
+      [dataProp, ownLoaderData, matches]
+    )
 
     if (weaverseData) {
       if (weaverseData instanceof Promise) {

--- a/packages/hydrogen/src/utils/pick-weaverse-data.ts
+++ b/packages/hydrogen/src/utils/pick-weaverse-data.ts
@@ -1,0 +1,78 @@
+import type { UIMatch } from 'react-router'
+import type { WeaverseLoaderData } from '../types'
+
+export type WeaverseDataValue =
+  | WeaverseLoaderData
+  | Promise<WeaverseLoaderData>
+  | null
+
+/**
+ * Resolve the `weaverseData` payload for a `<WeaverseHydrogenRoot>` instance.
+ *
+ * Resolution order (first match wins):
+ *
+ *  1. **Explicit prop** — the caller passed `data` directly. Used as-is,
+ *     including when it is a `Promise` (handled upstream via `<Await>`) or
+ *     an explicit `null` (suppresses rendering).
+ *  2. **Own route's loader data** — the loader data for the route that
+ *     rendered this component, obtained via `useLoaderData()`. This is
+ *     React Router's route-scoped primitive and is what makes nested
+ *     layout + child Weaverse pages work: each `<WeaverseContent />`
+ *     resolves to *its own* route's `weaverseData` regardless of siblings.
+ *  3. **Ancestor match fallback** — walk `useMatches()` from leaf to root
+ *     and return the first ancestor whose `loaderData` exposes a
+ *     `weaverseData` key. This preserves the long-standing behaviour where
+ *     a child route with no loader (e.g. an `index.tsx` that omits
+ *     `weaverseData`) still renders its layout's Weaverse page.
+ *
+ * The helper is intentionally pure (no hook calls) so it can be unit-tested
+ * without a React Router context. Hook calls happen in the component.
+ *
+ * ## Back-compat contract
+ *
+ * Themes that pre-date the `data` prop addition pass `dataProp === undefined`,
+ * so resolution starts at Tier 2. For the canonical single-instance pattern
+ * (one `<WeaverseContent />` inside a route whose loader returns
+ * `{ weaverseData }`), Tier 2 returns the same value the old `useMatches()`
+ * walk did. For the index-without-loader pattern (leaf route exposes no
+ * `weaverseData`, layout does), Tier 3's leaf→root walk produces an
+ * identical result to the pre-fix code. The only intentional behaviour
+ * change is the issue #451 case: two `<WeaverseContent />` instances on the
+ * same URL (layout + child, both with their own `weaverseData`) now each
+ * render their own page instead of both rendering the deepest one.
+ */
+export function pickWeaverseData(
+  dataProp: WeaverseDataValue | undefined,
+  ownLoaderData: unknown,
+  matches: ReadonlyArray<Pick<UIMatch, 'loaderData'>>
+): WeaverseDataValue {
+  // Tier 1: explicit prop wins (including explicit `null`).
+  if (dataProp !== undefined) {
+    return dataProp
+  }
+
+  // Tier 2: own route's loader data — the route-scoped primitive.
+  if (hasWeaverseData(ownLoaderData)) {
+    return ownLoaderData.weaverseData as WeaverseDataValue
+  }
+
+  // Tier 3: ancestor walk (leaf → root) for legacy / index-without-loader cases.
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const loaderData = matches[i].loaderData
+    if (hasWeaverseData(loaderData)) {
+      return loaderData.weaverseData as WeaverseDataValue
+    }
+  }
+
+  return null
+}
+
+function hasWeaverseData(
+  value: unknown
+): value is Record<string, unknown> & { weaverseData: unknown } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'weaverseData' in (value as Record<string, unknown>)
+  )
+}

--- a/packages/hydrogen/src/utils/pick-weaverse-data.ts
+++ b/packages/hydrogen/src/utils/pick-weaverse-data.ts
@@ -70,9 +70,16 @@ export function pickWeaverseData(
 function hasWeaverseData(
   value: unknown
 ): value is Record<string, unknown> & { weaverseData: unknown } {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'weaverseData' in (value as Record<string, unknown>)
-  )
+  // The `in` check alone returns true for `{ weaverseData: undefined }`,
+  // which would let Tier 2 short-circuit and return `undefined` — bypassing
+  // the Tier 3 ancestor walk that would otherwise resolve the missing data.
+  // Require the value to be present (not `undefined`).
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('weaverseData' in (value as Record<string, unknown>))
+  ) {
+    return false
+  }
+  return (value as Record<string, unknown>).weaverseData !== undefined
 }


### PR DESCRIPTION
Fixes Weaverse/weaverse#500.

## What changed

`WeaverseHydrogenRoot` previously resolved `weaverseData` by walking `useMatches()` and returning the deepest match's payload. Because `useMatches()` returns the same array for every component on the page, every `<WeaverseContent />` instance resolved to the same value — making it impossible for two instances (e.g. a layout-loaded page + a child-loaded page) to render different Weaverse pages on the same URL.

This PR restores the route-scoped primitive via `useLoaderData()` for the `weaverseData` lookup, while keeping the existing `useMatches()`-driven `createWeaverseDataContext` infrastructure untouched (it legitimately needs all matches to build the route-keyed data-connector context).

## How it resolves now

A pure helper `pickWeaverseData()` implements a three-tier policy:

1. **Explicit `data` prop** *(new — escape hatch)* — supports the typed `Route.ComponentProps.loaderData` framework-mode pattern and gives consumers full control.
2. **Own route's loader data** via `useLoaderData()` — React Router's route-scoped primitive; this is what makes layout + child compositions work.
3. **Ancestor walk** through `useMatches()` — back-compat fallback for the index-without-loader pattern (e.g. an `index.tsx` that omits `weaverseData` and inherits from its layout).

## Back-compat guarantee (verified)

- **Unmodified themes** (zero-prop `<WeaverseContent />`) work identically via Tier 2 for the common single-instance pattern.
- **Index leaves without loaders** continue to fall back to ancestor `weaverseData` via Tier 3.
- **Deferred (`Promise`) loaders** pass through unchanged at every tier.
- **`data?` prop is optional**; existing call sites compile unchanged (verified via generated `.d.ts`).
- **Only intentional behaviour change**: two `<WeaverseHydrogenRoot>` instances on the same URL now each render their own route's page instead of both rendering the deepest one — exactly the Weaverse/weaverse#500 fix.

The pilot wrapper (`templates/pilot/app/weaverse/index.tsx`) is intentionally **not** modified in this PR. The fix works end-to-end for unmodified pilots; updating the wrapper to forward an explicit `data` prop is a separate optional follow-up.

## Tests

18 new selector unit tests in `packages/hydrogen/__tests__/pick-weaverse-data.test.ts`:

- All three tiers (explicit prop incl. `null` + `Promise`, own loader data, ancestor walk)
- Non-object / null / undefined edge cases at every tier
- 5 dedicated back-compat scenarios mirroring legacy pilot route shapes
- Explicit Weaverse/weaverse#500 regression assertion: two instances with different `ownLoaderData` diverge despite an identical `matches` array

Local verification: `pnpm run biome && pnpm run typecheck && pnpm run test` — 91/91 hydrogen tests pass.

## Background — root cause history

The buggy resolver was introduced in commit `a21c8d5d` (Sep 23 2025, *"feat: enhance data connector with deep recursive replacement and performance optimizations"*), which migrated from `useLoaderData()` to a `useMatches()` walk under the banner *"60-70% memory improvement"*. Reading the diff, the real architectural motivation was building a flat route-keyed data context for `{{root.layout.shop.name}}`-style templates — which legitimately needs all matches. The `weaverseData` lookup was collapsed into the same walk only because `matches` was already in scope; that's the regression. The memory improvement claim appears only in CHANGELOGs (no benchmark in the repo) and pertains to the data-context rebuild, not to the `weaverseData` lookup specifically.

Commit `4dfcbea7` (Nov 12 2025) later reversed the iteration direction, flipping the failure mode from *"layout page renders twice"* to *"child page renders twice"* — which is what Weaverse/weaverse#500 reports.

## Second commit

`chore: replace bun with pnpm in releasing-weaverse-sdks skill` — follow-up to PR Weaverse/weaverse-sdk#450's package manager migration; this skill file was missed.
