### PR TITLE
fix(hydrogen): preserve studio bridge across data revalidation

### DIFF
--- a/packages/hydrogen/__tests__/studio-request-info.test.ts
+++ b/packages/hydrogen/__tests__/studio-request-info.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeDesignModeRequestInfo } from '../src/utils/studio-request-info'
+
+const baseParams = {
+  data: { id: 'page-1', name: 'Product', rootId: 'root', items: [] },
+  dataContext: {},
+  internal: { pageAssignment: { type: 'PRODUCT' }, project: {} },
+  isDesignMode: true,
+  pageId: 'page-1',
+  projectId: 'project-1',
+  requestInfo: {
+    i18n: { country: 'US', language: 'EN' },
+    pathname: '/_root.data',
+    queries: {},
+    search: '?_routes=routes/product',
+  },
+  weaverseApiBase: 'https://studio.weaverse.io',
+  weaverseApiKey: 'key',
+  weaverseHost: 'https://studio.weaverse.io',
+  weaverseVersion: '5.14.0',
+} as any
+
+describe('normalizeDesignModeRequestInfo', () => {
+  it('should_use_browser_location_for_design_mode_data_revalidation_requests', () => {
+    let normalized = normalizeDesignModeRequestInfo(baseParams, {
+      pathname: '/products/blue-shirt',
+      search: '?Color=Blue',
+    })
+
+    expect(normalized.requestInfo.pathname).toBe('/products/blue-shirt')
+    expect(normalized.requestInfo.search).toBe('?Color=Blue')
+    expect(normalized.requestInfo.queries).toEqual({ Color: 'Blue' })
+  })
+
+  it('should_replace_data_request_queries_with_browser_location_queries', () => {
+    let normalized = normalizeDesignModeRequestInfo(baseParams, {
+      pathname: '/products/blue-shirt',
+      search: '?available=true&Color=Blue',
+    })
+
+    expect(normalized.requestInfo.queries).toEqual({
+      Color: 'Blue',
+      available: true,
+    })
+  })
+
+  it('should_preserve_server_request_info_outside_design_mode', () => {
+    let normalized = normalizeDesignModeRequestInfo(
+      { ...baseParams, isDesignMode: false },
+      {
+        pathname: '/products/blue-shirt',
+        search: '?Color=Blue',
+      }
+    )
+
+    expect(normalized.requestInfo.pathname).toBe('/_root.data')
+    expect(normalized.requestInfo.search).toBe('?_routes=routes/product')
+  })
+})

--- a/packages/hydrogen/__tests__/weaverse-configs.test.ts
+++ b/packages/hydrogen/__tests__/weaverse-configs.test.ts
@@ -1,0 +1,54 @@
+import type { HydrogenEnv } from '@shopify/hydrogen'
+import { describe, expect, it } from 'vitest'
+import { getWeaverseConfigs } from '../src/utils'
+import { WeaverseClient } from '../src/weaverse-client'
+
+interface ClientWithPrivateApiUrl {
+  configs: {
+    projectId: string
+    weaverseApiBase: string
+    weaverseHost: string
+  }
+  getApiUrl: (endpoint: string) => string
+}
+
+describe('getWeaverseConfigs', () => {
+  it('should_default_api_base_to_studio_host', () => {
+    let configs = getWeaverseConfigs(
+      new Request('https://example.com/products/blue-shirt'),
+      { WEAVERSE_PROJECT_ID: 'project-1' } as unknown as HydrogenEnv
+    )
+
+    expect(configs.weaverseApiBase).toBe('https://studio.weaverse.io')
+  })
+
+  it('should_ignore_legacy_api_base_when_studio_host_is_configured', () => {
+    let configs = getWeaverseConfigs(
+      new Request('https://example.com/products/blue-shirt'),
+      {
+        WEAVERSE_API_BASE: 'https://legacy-api.example.com',
+        WEAVERSE_HOST: 'https://studio.weaverse.io',
+        WEAVERSE_PROJECT_ID: 'project-1',
+      } as unknown as HydrogenEnv
+    )
+
+    expect(configs.weaverseApiBase).toBe('https://studio.weaverse.io')
+  })
+})
+
+describe('WeaverseClient API URLs', () => {
+  it('should_build_api_urls_from_studio_host', () => {
+    let client = Object.create(
+      WeaverseClient.prototype
+    ) as ClientWithPrivateApiUrl
+    client.configs = {
+      projectId: 'project-1',
+      weaverseApiBase: 'https://legacy-api.example.com',
+      weaverseHost: 'https://studio.weaverse.io',
+    }
+
+    let url = client.getApiUrl('project_configs')
+
+    expect(url).toBe('https://studio.weaverse.io/api/public/project_configs')
+  })
+})

--- a/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
+++ b/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
@@ -50,6 +50,7 @@ import {
   pickWeaverseData,
   type WeaverseDataValue,
 } from './utils/pick-weaverse-data'
+import { normalizeDesignModeRequestInfo } from './utils/studio-request-info'
 import { ThemeTextStore } from './utils/theme-text-store'
 import { useStudio } from './utils/use-studio'
 import {
@@ -289,28 +290,30 @@ export class WeaverseHydrogen extends Weaverse {
 function createWeaverseInstance(
   params: WeaverseHydrogenParams
 ): WeaverseHydrogen {
+  const normalizedParams = normalizeDesignModeRequestInfo(params)
   if (isBrowser) {
     // Check if the weaverse instance already exists in the window object
     window.__weaverses = window.__weaverses || {}
-    let weaverse = window.__weaverses[params.pageId]
+    let weaverse = window.__weaverses[normalizedParams.pageId]
     // If the weaverse instance does not exist, or the pathname or search has changed, create a new instance
     if (
       !weaverse ||
-      weaverse?.requestInfo?.pathname !== params.requestInfo.pathname ||
-      weaverse?.requestInfo?.search !== params.requestInfo.search
+      weaverse?.requestInfo?.pathname !==
+        normalizedParams.requestInfo.pathname ||
+      weaverse?.requestInfo?.search !== normalizedParams.requestInfo.search
     ) {
-      weaverse = new WeaverseHydrogen(params)
-      window.__weaverses[params.pageId] = weaverse
+      weaverse = new WeaverseHydrogen(normalizedParams)
+      window.__weaverses[normalizedParams.pageId] = weaverse
     }
     if (weaverse?.isDesignMode) {
-      weaverse.requestInfo = params.requestInfo
+      weaverse.requestInfo = normalizedParams.requestInfo
       if (hasWeaverseStudio(window)) {
-        window.weaverseStudio.refreshStudio(params)
+        window.weaverseStudio.refreshStudio(normalizedParams)
       }
     }
     return weaverse
   }
-  return new WeaverseHydrogen(params)
+  return new WeaverseHydrogen(normalizedParams)
 }
 
 const StudioBridge = memo(({ context }: { context: WeaverseHydrogen }) => {

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -632,7 +632,6 @@ declare module '@shopify/hydrogen' {
     PUBLIC_SHOPIFY_INBOX_SHOP_ID: string
     PUBLIC_STORE_DOMAIN: string
     PUBLIC_STOREFRONT_API_TOKEN: string
-    WEAVERSE_API_BASE?: string
     WEAVERSE_API_KEY: string
     WEAVERSE_HOST?: string
     WEAVERSE_PROJECT_ID: string

--- a/packages/hydrogen/src/utils/index.ts
+++ b/packages/hydrogen/src/utils/index.ts
@@ -97,7 +97,6 @@ export function getWeaverseConfigs(
     WEAVERSE_PROJECT_ID,
     WEAVERSE_API_KEY,
     WEAVERSE_HOST,
-    WEAVERSE_API_BASE,
     PUBLIC_STORE_DOMAIN,
     PUBLIC_STOREFRONT_API_TOKEN,
   } = env || {}
@@ -114,6 +113,11 @@ export function getWeaverseConfigs(
 
   let url = new URL(request.url)
   let isRevisionPreview = url.searchParams.has('__revisionId')
+  let resolvedWeaverseHost =
+    weaverseHost ||
+    WEAVERSE_HOST ||
+    envFromProcess.WEAVERSE_HOST ||
+    'https://studio.weaverse.io'
 
   return {
     projectId:
@@ -121,17 +125,8 @@ export function getWeaverseConfigs(
       WEAVERSE_PROJECT_ID ||
       envFromProcess.WEAVERSE_PROJECT_ID ||
       '',
-    weaverseHost:
-      weaverseHost ||
-      WEAVERSE_HOST ||
-      envFromProcess.WEAVERSE_HOST ||
-      'https://studio.weaverse.io',
-    weaverseApiBase:
-      WEAVERSE_API_BASE ||
-      envFromProcess.WEAVERSE_API_BASE ||
-      WEAVERSE_HOST ||
-      envFromProcess.WEAVERSE_HOST ||
-      'https://api.weaverse.io',
+    weaverseHost: resolvedWeaverseHost,
+    weaverseApiBase: resolvedWeaverseHost,
     weaverseApiKey:
       weaverseApiKey ||
       WEAVERSE_API_KEY ||

--- a/packages/hydrogen/src/utils/studio-request-info.ts
+++ b/packages/hydrogen/src/utils/studio-request-info.ts
@@ -1,0 +1,64 @@
+import type { WeaverseHydrogenParams } from '../types'
+
+interface BrowserLocationLike {
+  pathname: string
+  search: string
+}
+
+function getBrowserLocation(): BrowserLocationLike | undefined {
+  if (typeof window === 'undefined') {
+    return
+  }
+  return window.location
+}
+
+function getQueriesFromSearch(
+  search: string
+): Record<string, string | boolean> {
+  let queries: Record<string, string | boolean> = {}
+  let params = new URLSearchParams(search)
+  for (let [key, value] of params.entries()) {
+    if (value === 'true') {
+      queries[key] = true
+    } else if (value === 'false') {
+      queries[key] = false
+    } else {
+      queries[key] = value
+    }
+  }
+  return queries
+}
+
+/**
+ * React Router v7 single-fetch revalidation can render client data returned from
+ * a `/_root.data` request while the browser is still on the merchant-facing
+ * preview URL. In design mode, Studio instance identity must follow the browser
+ * URL, not the transient data endpoint, otherwise the SDK creates a fresh
+ * Weaverse instance without the existing Studio bridge/interactions attached.
+ */
+export function normalizeDesignModeRequestInfo(
+  params: WeaverseHydrogenParams,
+  browserLocation: BrowserLocationLike | undefined = getBrowserLocation()
+): WeaverseHydrogenParams {
+  if (!(params.isDesignMode && browserLocation)) {
+    return params
+  }
+
+  let { pathname, search } = browserLocation
+  if (
+    params.requestInfo.pathname === pathname &&
+    params.requestInfo.search === search
+  ) {
+    return params
+  }
+
+  return {
+    ...params,
+    requestInfo: {
+      ...params.requestInfo,
+      pathname,
+      queries: getQueriesFromSearch(search),
+      search,
+    },
+  }
+}

--- a/packages/hydrogen/src/weaverse-client.ts
+++ b/packages/hydrogen/src/weaverse-client.ts
@@ -486,16 +486,8 @@ export class WeaverseClient {
   }
 
   // Helper method for building API URLs consistently
-  private getApiUrl(
-    endpoint: string,
-    useProxy = !this.configs.isDesignMode
-  ): string {
-    const { weaverseHost, weaverseApiBase, projectId } = this.configs
-
-    if (useProxy) {
-      return `${weaverseApiBase}/v1/${endpoint}?projectId=${projectId}`
-    }
-
+  private getApiUrl(endpoint: string): string {
+    const { weaverseHost } = this.configs
     return `${weaverseHost}/api/public/${endpoint}`
   }
 


### PR DESCRIPTION
## Summary

- normalize design-mode request info to the browser URL before creating or refreshing the Hydrogen Studio instance
- keep normalized `requestInfo.queries` in sync with the browser URL query string instead of the React Router single-fetch data endpoint query string
- prevent React Router v7 single-fetch `/_root.data` revalidation responses from creating a fresh Weaverse instance without the existing Studio bridge
- route Hydrogen SDK API calls through `studio.weaverse.io/api/public/*` and stop using the legacy `api.weaverse.io` proxy/default
- add regression coverage for design-mode data revalidation request info normalization and Studio-host API URL generation

## Root cause

After a design-mode revalidation, React Router v7 single-fetch can return loader data whose server-side request URL is `/_root.data` while the preview iframe is still on the real storefront URL. The Hydrogen SDK used that request info for Studio instance identity, so the preview could create a new Weaverse instance that did not have `studioBridge.eventHandlers` attached. Once that happened, the preview rendered but could no longer be clicked or synced from Studio after revalidation completed.

## Test plan

- `pnpm exec vp test --run packages/hydrogen/__tests__/studio-request-info.test.ts packages/hydrogen/__tests__/weaverse-configs.test.ts packages/hydrogen/__tests__/pick-weaverse-data.test.ts`
- `pnpm --filter @weaverse/hydrogen typecheck`
- `pnpm biome packages/hydrogen/src/utils/studio-request-info.ts packages/hydrogen/__tests__/studio-request-info.test.ts packages/hydrogen/src/utils/index.ts packages/hydrogen/src/weaverse-client.ts packages/hydrogen/src/types.ts packages/hydrogen/__tests__/weaverse-configs.test.ts packages/hydrogen/src/WeaverseHydrogenRoot.tsx`
