### PR TITLE
Use smart cache for Builder API requests

### DIFF
--- a/packages/hydrogen/__tests__/weaverse-client.test.ts
+++ b/packages/hydrogen/__tests__/weaverse-client.test.ts
@@ -276,6 +276,68 @@ describe('WeaverseClient Multi-Project Architecture', () => {
 
       expect(weaverse.configs.projectId).toBe('project-abc')
     })
+
+    it('should use smart shared cache strategy for Builder API requests', async () => {
+      let weaverse = new WeaverseClient({
+        ...mockContext,
+        components: mockComponents,
+        themeSchema: mockThemeSchema,
+        projectId: 'project-abc',
+      })
+      let fetchWithCache = mock(async () => ({
+        data: { ok: true },
+        response: new Response('{}'),
+      }))
+      weaverse.withCache.fetch = fetchWithCache
+
+      await weaverse.fetchWithCache(
+        'https://studio.weaverse.io/api/public/project',
+        {
+          method: 'POST',
+          body: JSON.stringify({ projectId: 'project-abc' }),
+          cacheTarget: 'project' as any,
+        }
+      )
+
+      expect(fetchWithCache.mock.calls[0][2].cacheStrategy).toMatchObject({
+        maxAge: 60,
+        sMaxAge: 300,
+        staleWhileRevalidate: 86_400,
+        staleIfError: 86_400,
+      })
+    })
+
+    it('should let explicit strategy override smart cache defaults', async () => {
+      let weaverse = new WeaverseClient({
+        ...mockContext,
+        components: mockComponents,
+        themeSchema: mockThemeSchema,
+        projectId: 'project-abc',
+      })
+      let explicitStrategy = {
+        maxAge: 1,
+        sMaxAge: 2,
+        staleWhileRevalidate: 3,
+        staleIfError: 4,
+      }
+      let fetchWithCache = mock(async () => ({
+        data: { ok: true },
+        response: new Response('{}'),
+      }))
+      weaverse.withCache.fetch = fetchWithCache
+
+      await weaverse.fetchWithCache(
+        'https://studio.weaverse.io/api/public/project',
+        {
+          cacheTarget: 'project' as any,
+          strategy: explicitStrategy,
+        }
+      )
+
+      expect(fetchWithCache.mock.calls[0][2].cacheStrategy).toBe(
+        explicitStrategy
+      )
+    })
   })
 
   describe('T032: Route-Level Override', () => {

--- a/packages/hydrogen/__tests__/weaverse-client.test.ts
+++ b/packages/hydrogen/__tests__/weaverse-client.test.ts
@@ -338,6 +338,37 @@ describe('WeaverseClient Multi-Project Architecture', () => {
         explicitStrategy
       )
     })
+
+    it('should bypass shared cache for revision previews', async () => {
+      let request = new Request(
+        'https://test-store.myshopify.com/?__revisionId=rev-123'
+      )
+      let weaverse = new WeaverseClient({
+        ...createMockContext({ request }),
+        components: mockComponents,
+        themeSchema: mockThemeSchema,
+        projectId: 'project-abc',
+      })
+      let fetchWithCache = mock(async () => ({
+        data: { ok: true },
+        response: new Response('{}'),
+      }))
+      let directFetch = mock(async () => ({
+        data: { ok: true },
+        response: new Response('{}'),
+      }))
+      weaverse.withCache.fetch = fetchWithCache
+      ;(weaverse as any).directFetch = directFetch
+
+      await weaverse.fetchWithCache(
+        'https://studio.weaverse.io/api/public/project',
+        { cacheTarget: 'project' as any }
+      )
+
+      expect(weaverse.configs.isRevisionPreview).toBe(true)
+      expect(directFetch).toHaveBeenCalledTimes(1)
+      expect(fetchWithCache).not.toHaveBeenCalled()
+    })
   })
 
   describe('T032: Route-Level Override', () => {

--- a/packages/hydrogen/src/weaverse-client.ts
+++ b/packages/hydrogen/src/weaverse-client.ts
@@ -559,7 +559,10 @@ export class WeaverseClient {
 
     let result: WithCacheFetchResponse<T>
 
-    if (this.configs.isDesignMode) {
+    // Bypass the shared cache for design mode and revision previews:
+    // both must always reflect the latest Builder state, and caching
+    // one-off revision responses would only pollute the cache.
+    if (this.configs.isDesignMode || this.configs.isRevisionPreview) {
       result = await this.directFetch<T>(url, fetchOptions)
     } else {
       // Use withCache.fetch for better integration with Hydrogen's caching system

--- a/packages/hydrogen/src/weaverse-client.ts
+++ b/packages/hydrogen/src/weaverse-client.ts
@@ -40,10 +40,14 @@ import {
  * These values optimize CDN hit rates while maintaining fresh content.
  */
 const CACHE_DURATIONS = {
-  /** Short cache for frequently changing content (10 seconds) */
-  SHORT: 10,
-  /** Long cache duration - 23 hours to maximize CDN hits before daily refresh */
-  LONG: 82_800,
+  /** Short browser freshness for content that can change in Builder */
+  SHORT: 60,
+  /** Shared cache freshness for anonymous storefront traffic */
+  SHARED_SHORT: 300,
+  /** Long stale window so slow Builder responses do not block storefront rendering */
+  LONG: 86_400,
+  /** Extra freshness for sitemap-like index data */
+  STATIC: 3600,
 } as const
 
 /**
@@ -63,9 +67,27 @@ const API_PATH = 'v1' as const
  */
 const DEFAULT_CACHE_STRATEGY: CachingStrategy = {
   maxAge: CACHE_DURATIONS.SHORT,
-  sMaxAge: CACHE_DURATIONS.SHORT,
+  sMaxAge: CACHE_DURATIONS.SHARED_SHORT,
   staleWhileRevalidate: CACHE_DURATIONS.LONG,
   staleIfError: CACHE_DURATIONS.LONG,
+} as const
+
+type BuilderApiCacheTarget =
+  | 'custom-pages'
+  | 'merchant-overrides'
+  | 'project'
+  | 'theme-settings'
+
+const SMART_CACHE_STRATEGIES: Record<BuilderApiCacheTarget, CachingStrategy> = {
+  project: DEFAULT_CACHE_STRATEGY,
+  'theme-settings': DEFAULT_CACHE_STRATEGY,
+  'merchant-overrides': DEFAULT_CACHE_STRATEGY,
+  'custom-pages': {
+    maxAge: CACHE_DURATIONS.SHORT,
+    sMaxAge: CACHE_DURATIONS.STATIC,
+    staleWhileRevalidate: CACHE_DURATIONS.LONG,
+    staleIfError: CACHE_DURATIONS.LONG,
+  },
 } as const
 
 export class WeaverseClient {
@@ -510,9 +532,19 @@ export class WeaverseClient {
    */
   public fetchWithCache = async <T = unknown>(
     url: string,
-    options: RequestInit & { strategy?: CachingStrategy } = {}
+    options: RequestInit & {
+      cacheTarget?: BuilderApiCacheTarget
+      strategy?: CachingStrategy
+    } = {}
   ): Promise<T> => {
-    const strategy = options.strategy || CacheCustom(DEFAULT_CACHE_STRATEGY)
+    const { cacheTarget, strategy: strategyOverride, ...fetchOptions } = options
+    const strategy =
+      strategyOverride ||
+      CacheCustom(
+        cacheTarget
+          ? SMART_CACHE_STRATEGIES[cacheTarget]
+          : DEFAULT_CACHE_STRATEGY
+      )
 
     // Update cache key to include method, body content, and projectId for multi-project isolation
     // Prefix for easier debugging in cache systems
@@ -520,17 +552,18 @@ export class WeaverseClient {
       'weaverse-fetch',
       url,
       options.method || 'GET',
-      options.body,
+      fetchOptions.body,
       this.configs.projectId,
+      cacheTarget || 'default',
     ]
 
     let result: WithCacheFetchResponse<T>
 
     if (this.configs.isDesignMode) {
-      result = await this.directFetch<T>(url, options)
+      result = await this.directFetch<T>(url, fetchOptions)
     } else {
       // Use withCache.fetch for better integration with Hydrogen's caching system
-      result = (await this.withCache.fetch(url, options, {
+      result = (await this.withCache.fetch(url, fetchOptions, {
         cacheKey,
         cacheStrategy: strategy,
         shouldCacheResponse: (response: any): boolean => {
@@ -578,6 +611,7 @@ export class WeaverseClient {
       const [data, merchantOverrides] = await Promise.all([
         this.fetchWithCache<ThemeSettingsResponse>(url, {
           method: 'POST',
+          cacheTarget: 'theme-settings',
           strategy,
           body,
           headers: {
@@ -699,6 +733,7 @@ export class WeaverseClient {
         url,
         {
           method: 'GET',
+          cacheTarget: 'merchant-overrides',
           strategy,
           headers: {
             Accept: 'application/json',
@@ -778,7 +813,7 @@ export class WeaverseClient {
         const result = await this.fetchWithCache<{
           data: CustomPageEntry[]
           nextCursor: string | null
-        }>(url)
+        }>(url, { cacheTarget: 'custom-pages' })
         entries.push(...(result.data || []))
 
         if (!result.nextCursor) {
@@ -906,6 +941,7 @@ export class WeaverseClient {
       const projectData: FetchProjectPayload =
         await this.fetchWithCache<FetchProjectPayload>(url, {
           ...reqInit,
+          cacheTarget: 'project',
           strategy,
         })
 

--- a/packages/i18n/__tests__/server.test.ts
+++ b/packages/i18n/__tests__/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { WeaverseI18nServer } from '../src/server'
 
 let defaultConfig = {
@@ -122,6 +122,47 @@ describe('WeaverseI18nServer', () => {
       let server = new WeaverseI18nServer(defaultConfig)
       let request = new Request('https://example.com/')
       expect(server.getLocale(request)).toBe('en')
+    })
+  })
+
+  describe('getI18nData cache', () => {
+    it('should include Builder source and project in the cache key', () => {
+      let server = new WeaverseI18nServer({
+        ...defaultConfig,
+        host: 'https://studio.weaverse.io',
+        localUrl: '/locales/{{lng}}/{{ns}}.json',
+      })
+
+      let cacheKey = (server as any)._getCacheKey({
+        lng: 'en',
+        ns: ['common', 'product'],
+      })
+
+      expect(cacheKey).toBe(
+        'test-project|https://studio.weaverse.io|/locales/{{lng}}/{{ns}}.json|en|common,product'
+      )
+    })
+
+    it('should reuse cached loads only for the same project/source/locale/namespace tuple', async () => {
+      let server = new WeaverseI18nServer({
+        ...defaultConfig,
+        bundledResources: {
+          en: { common: { greeting: 'Hello' } },
+        },
+      })
+      let loadSpy = vi.spyOn(server as any, '_loadI18nData')
+
+      await server.getI18nData(new Request('https://example.com/'), {
+        lng: 'en',
+        ns: 'common',
+      })
+      await server.getI18nData(new Request('https://example.com/'), {
+        lng: 'en',
+        ns: 'common',
+      })
+
+      expect(loadSpy).toHaveBeenCalledTimes(1)
+      loadSpy.mockRestore()
     })
   })
 })

--- a/packages/i18n/src/server.ts
+++ b/packages/i18n/src/server.ts
@@ -193,7 +193,7 @@ export class WeaverseI18nServer {
   ): Promise<WeaverseI18nData> {
     let lng = options?.lng || this.getLocale(request)
     let ns = options?.ns || this._config.defaultNS
-    let cacheKey = `${lng}|${Array.isArray(ns) ? ns.join(',') : ns}`
+    let cacheKey = this._getCacheKey({ lng, ns })
     let ttl = this._config.cacheTTL ?? 5 * 60 * 1000
 
     // Check cache — uses a Promise to deduplicate concurrent requests
@@ -258,6 +258,27 @@ export class WeaverseI18nServer {
   ): Promise<TFunction> {
     let instance = await this.createInstance(request, { ns })
     return instance.t.bind(instance)
+  }
+
+  private _getCacheKey({
+    lng,
+    ns,
+  }: {
+    lng: string
+    ns: string | string[]
+  }): string {
+    let namespaceKey = Array.isArray(ns) ? ns.join(',') : ns
+    let host = this._config.host || 'https://weaverse.io'
+    let apiSource = this._config.apiUrl || host
+    let localSource = this._config.localUrl || ''
+
+    return [
+      this._config.projectId,
+      apiSource,
+      localSource,
+      lng,
+      namespaceKey,
+    ].join('|')
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add smart cache targets for Builder API calls in `@weaverse/hydrogen`.
- Apply shared-cache defaults to page, theme settings, and merchant override requests.
- Use a longer shared-cache window for custom page index requests used by sitemap-style loaders.
- Keep design mode/revision behavior uncached through direct fetch, and preserve explicit `strategy` overrides for storefronts that need custom behavior.
- Improve `@weaverse/i18n` server cache isolation by including project/source/locale/namespace in the cache key.

## Verification

- `pnpm exec vp test --run packages/hydrogen/__tests__/weaverse-client.test.ts packages/i18n/__tests__/server.test.ts`
- `pnpm run biome -- packages/hydrogen/src/weaverse-client.ts packages/hydrogen/__tests__/weaverse-client.test.ts packages/i18n/src/server.ts packages/i18n/__tests__/server.test.ts`
- `pnpm --filter @weaverse/hydrogen typecheck && pnpm --filter @weaverse/i18n typecheck`
- `pnpm --filter @weaverse/hydrogen build && pnpm --filter @weaverse/i18n build`

Note: pre-commit surfaced existing warnings in the touched files, but the focused Biome command with `--diagnostic-level=error` passed.