### PR TITLE
fix: harden studio handshake and instance identity for nested Weaverse pages

### DIFF
--- a/packages/core/__tests__/load-script.test.ts
+++ b/packages/core/__tests__/load-script.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadScript } from '../src/utils'
+
+interface FakeScript {
+  defer: boolean
+  onerror: ((error?: unknown) => void) | null
+  onload: ((value?: unknown) => void) | null
+  remove: () => void
+  src: string
+}
+
+const SCRIPT_SRC_SELECTOR_RE = /^script\[src="(.*)"\]$/
+
+let appendedScripts: FakeScript[]
+
+function createFakeScript(): FakeScript {
+  const script: FakeScript = {
+    src: '',
+    defer: false,
+    onload: null,
+    onerror: null,
+    remove: () => {
+      appendedScripts = appendedScripts.filter((s) => s !== script)
+    },
+  }
+  return script
+}
+
+beforeEach(() => {
+  appendedScripts = []
+  vi.stubGlobal('document', {
+    querySelector: (selector: string) => {
+      const src = selector.match(SCRIPT_SRC_SELECTOR_RE)?.[1]
+      return appendedScripts.find((s) => s.src === src) ?? null
+    },
+    createElement: () => createFakeScript(),
+    body: {
+      appendChild: (script: FakeScript) => {
+        appendedScripts.push(script)
+      },
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('loadScript', () => {
+  it('should_share_one_promise_and_resolve_only_after_script_executes', async () => {
+    const src = 'https://studio.weaverse.io/static/studio/hydrogen/index.js'
+    let first = loadScript(src)
+    let second = loadScript(src)
+
+    // Same in-flight promise; only one tag appended.
+    expect(second).toBe(first)
+    expect(appendedScripts).toHaveLength(1)
+
+    let settled = false
+    let tracked = first.then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    // The regression: callers must NOT resolve while the tag merely exists.
+    expect(settled).toBe(false)
+
+    appendedScripts[0].onload?.('load-event')
+    await expect(first).resolves.toBe('load-event')
+    await tracked
+    expect(settled).toBe(true)
+  })
+
+  it('should_resolve_immediately_for_tags_injected_outside_loadScript', async () => {
+    const src = 'https://example.com/preinjected.js'
+    const external = createFakeScript()
+    external.src = src
+    appendedScripts.push(external)
+
+    await expect(loadScript(src)).resolves.toBe(true)
+    // No new tag was appended.
+    expect(appendedScripts).toHaveLength(1)
+  })
+
+  it('should_clear_cache_and_remove_tag_on_error_to_allow_retry', async () => {
+    const src = 'https://example.com/flaky.js'
+    let first = loadScript(src)
+    appendedScripts[0].onerror?.(new Error('network'))
+    await expect(first).rejects.toBeInstanceOf(Error)
+    expect(appendedScripts).toHaveLength(0)
+
+    // Retry creates a fresh tag and a fresh promise.
+    let second = loadScript(src)
+    expect(second).not.toBe(first)
+    expect(appendedScripts).toHaveLength(1)
+    appendedScripts[0].onload?.('load-event')
+    await expect(second).resolves.toBe('load-event')
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,8 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "clean": "rimraf dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vp test --run"
   },
   "tsup": {
     "entry": [

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -25,17 +25,34 @@ export function merge(
   return t
 }
 
+// Cache in-flight/settled loads per src. A bare `querySelector` check is not
+// enough: the tag exists as soon as the first caller appends it, so a second
+// caller arriving before the script *executes* would resolve early and read
+// globals (e.g. `window.weaverseStudio`) that aren't set yet. See issue #451.
+let scriptLoadPromises = new Map<string, Promise<unknown>>()
 export function loadScript(src: string) {
-  return new Promise((resolve, reject) => {
+  let pending = scriptLoadPromises.get(src)
+  if (pending) {
+    return pending
+  }
+  let promise = new Promise((resolve, reject) => {
     let currScript = document.querySelector(`script[src="${src}"]`)
     if (currScript) {
+      // Tag injected outside loadScript (e.g. SSR markup) — assume executed.
       return resolve(true)
     }
     let script = document.createElement('script')
     script.src = src
     script.onload = resolve
-    script.onerror = reject
+    script.onerror = (error) => {
+      // Drop the cache entry and the broken tag so a later call can retry.
+      scriptLoadPromises.delete(src)
+      script.remove()
+      reject(error)
+    }
     script.defer = true
     document.body.appendChild(script)
   })
+  scriptLoadPromises.set(src, promise)
+  return promise
 }

--- a/packages/hydrogen/__tests__/studio-request-info.test.ts
+++ b/packages/hydrogen/__tests__/studio-request-info.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeDesignModeRequestInfo } from '../src/utils/studio-request-info'
+import type { WeaverseHydrogenParams } from '../src/types'
+import { normalizeRequestInfo } from '../src/utils/studio-request-info'
 
+// Test fixture only exercises the requestInfo branch — the remaining
+// WeaverseHydrogenParams fields are irrelevant here, so an unchecked cast
+// keeps the fixture small without disabling checks at the call sites.
 const baseParams = {
   data: { id: 'page-1', name: 'Product', rootId: 'root', items: [] },
   dataContext: {},
@@ -18,11 +22,11 @@ const baseParams = {
   weaverseApiKey: 'key',
   weaverseHost: 'https://studio.weaverse.io',
   weaverseVersion: '5.14.0',
-} as any
+} as unknown as WeaverseHydrogenParams
 
-describe('normalizeDesignModeRequestInfo', () => {
+describe('normalizeRequestInfo', () => {
   it('should_use_browser_location_for_design_mode_data_revalidation_requests', () => {
-    let normalized = normalizeDesignModeRequestInfo(baseParams, {
+    let normalized = normalizeRequestInfo(baseParams, {
       pathname: '/products/blue-shirt',
       search: '?Color=Blue',
     })
@@ -33,7 +37,7 @@ describe('normalizeDesignModeRequestInfo', () => {
   })
 
   it('should_replace_data_request_queries_with_browser_location_queries', () => {
-    let normalized = normalizeDesignModeRequestInfo(baseParams, {
+    let normalized = normalizeRequestInfo(baseParams, {
       pathname: '/products/blue-shirt',
       search: '?available=true&Color=Blue',
     })
@@ -44,14 +48,40 @@ describe('normalizeDesignModeRequestInfo', () => {
     })
   })
 
-  it('should_preserve_server_request_info_outside_design_mode', () => {
-    let normalized = normalizeDesignModeRequestInfo(
+  it('should_normalize_live_theme_revalidation_requests_to_browser_location', () => {
+    let normalized = normalizeRequestInfo(
       { ...baseParams, isDesignMode: false },
       {
         pathname: '/products/blue-shirt',
         search: '?Color=Blue',
       }
     )
+
+    expect(normalized.requestInfo.pathname).toBe('/products/blue-shirt')
+    expect(normalized.requestInfo.search).toBe('?Color=Blue')
+    expect(normalized.requestInfo.queries).toEqual({ Color: 'Blue' })
+  })
+
+  it('should_return_params_unchanged_when_already_matching_browser_location', () => {
+    let params = {
+      ...baseParams,
+      requestInfo: {
+        ...baseParams.requestInfo,
+        pathname: '/products/blue-shirt',
+        search: '?Color=Blue',
+      },
+    }
+
+    let normalized = normalizeRequestInfo(params, {
+      pathname: '/products/blue-shirt',
+      search: '?Color=Blue',
+    })
+
+    expect(normalized).toBe(params)
+  })
+
+  it('should_preserve_server_request_info_without_browser_location', () => {
+    let normalized = normalizeRequestInfo(baseParams, undefined)
 
     expect(normalized.requestInfo.pathname).toBe('/_root.data')
     expect(normalized.requestInfo.search).toBe('?_routes=routes/product')

--- a/packages/hydrogen/__tests__/sync-reused-instance.test.ts
+++ b/packages/hydrogen/__tests__/sync-reused-instance.test.ts
@@ -1,0 +1,84 @@
+import type { Mock } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import type { WeaverseHydrogenParams } from '../src/types'
+import { syncReusedInstance } from '../src/utils/sync-reused-instance'
+import type { WeaverseHydrogen } from '../src/WeaverseHydrogenRoot'
+
+interface InstanceStub {
+  data: { id: string; rootId: string; items: { id: string }[] }
+  dataContext: Record<string, unknown> | null
+  internal: Record<string, unknown>
+  requestInfo: { pathname: string; search: string }
+  setProjectData: Mock
+  triggerUpdate: Mock
+}
+
+function makeInstance(): InstanceStub {
+  return {
+    data: { id: 'page-1', rootId: 'root', items: [{ id: 'item-1' }] },
+    dataContext: { cartCount: 0 },
+    internal: { project: { id: 'old' } },
+    requestInfo: { pathname: '/products/shirt', search: '' },
+    setProjectData: vi.fn(),
+    triggerUpdate: vi.fn(),
+  }
+}
+
+function makeParams(overrides: {
+  data?: InstanceStub['data']
+  dataContext?: Record<string, unknown>
+}): WeaverseHydrogenParams {
+  // Only the synced fields matter — the rest of the params surface is
+  // irrelevant here, hence the unchecked cast.
+  return {
+    data: overrides.data ?? {
+      id: 'page-1',
+      rootId: 'root',
+      items: [{ id: 'item-1' }],
+    },
+    dataContext: overrides.dataContext ?? { cartCount: 0 },
+    internal: { project: { id: 'new' } },
+    requestInfo: { pathname: '/products/shirt', search: '?fresh=1' },
+  } as unknown as WeaverseHydrogenParams
+}
+
+function sync(instance: InstanceStub, params: WeaverseHydrogenParams) {
+  syncReusedInstance(instance as unknown as WeaverseHydrogen, params)
+}
+
+describe('syncReusedInstance', () => {
+  it('should_apply_fresh_page_data_and_rerender_when_items_changed', () => {
+    let instance = makeInstance()
+    let params = makeParams({
+      data: { id: 'page-1', rootId: 'root', items: [{ id: 'item-2' }] },
+    })
+
+    sync(instance, params)
+
+    expect(instance.setProjectData).toHaveBeenCalledWith(params.data)
+    expect(instance.triggerUpdate).toHaveBeenCalledTimes(1)
+    // requestInfo/internal always follow the latest loader payload.
+    expect(instance.requestInfo).toBe(params.requestInfo)
+    expect(instance.internal).toBe(params.internal)
+  })
+
+  it('should_apply_fresh_data_context_without_rebuilding_page_data', () => {
+    let instance = makeInstance()
+    let params = makeParams({ dataContext: { cartCount: 3 } })
+
+    sync(instance, params)
+
+    expect(instance.setProjectData).not.toHaveBeenCalled()
+    expect(instance.dataContext).toEqual({ cartCount: 3 })
+    expect(instance.triggerUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('should_not_rerender_when_payload_is_unchanged', () => {
+    let instance = makeInstance()
+
+    sync(instance, makeParams({}))
+
+    expect(instance.setProjectData).not.toHaveBeenCalled()
+    expect(instance.triggerUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/hydrogen/__tests__/sync-reused-instance.test.ts
+++ b/packages/hydrogen/__tests__/sync-reused-instance.test.ts
@@ -8,6 +8,7 @@ interface InstanceStub {
   data: { id: string; rootId: string; items: { id: string }[] }
   dataContext: Record<string, unknown> | null
   internal: Record<string, unknown>
+  itemInstances: Map<string, { setData: Mock }>
   requestInfo: { pathname: string; search: string }
   setProjectData: Mock
   triggerUpdate: Mock
@@ -18,6 +19,7 @@ function makeInstance(): InstanceStub {
     data: { id: 'page-1', rootId: 'root', items: [{ id: 'item-1' }] },
     dataContext: { cartCount: 0 },
     internal: { project: { id: 'old' } },
+    itemInstances: new Map([['item-1', { setData: vi.fn() }]]),
     requestInfo: { pathname: '/products/shirt', search: '' },
     setProjectData: vi.fn(),
     triggerUpdate: vi.fn(),
@@ -62,7 +64,25 @@ describe('syncReusedInstance', () => {
     expect(instance.internal).toBe(params.internal)
   })
 
-  it('should_apply_fresh_data_context_without_rebuilding_page_data', () => {
+  it('should_assign_fresh_context_before_rebuilding_page_data', () => {
+    let instance = makeInstance()
+    let contextAtRebuild: unknown = 'never-called'
+    instance.setProjectData.mockImplementation(() => {
+      contextAtRebuild = instance.dataContext
+    })
+    let params = makeParams({
+      data: { id: 'page-1', rootId: 'root', items: [{ id: 'item-2' }] },
+      dataContext: { cartCount: 5 },
+    })
+
+    sync(instance, params)
+
+    // Item re-renders triggered by setProjectData must already resolve
+    // data connectors against the fresh context.
+    expect(contextAtRebuild).toEqual({ cartCount: 5 })
+  })
+
+  it('should_notify_item_stores_when_only_data_context_changed', () => {
     let instance = makeInstance()
     let params = makeParams({ dataContext: { cartCount: 3 } })
 
@@ -70,6 +90,11 @@ describe('syncReusedInstance', () => {
 
     expect(instance.setProjectData).not.toHaveBeenCalled()
     expect(instance.dataContext).toEqual({ cartCount: 3 })
+    // Memoized item components only re-render when their store snapshot
+    // identity changes — setData({}) swaps the reference per item.
+    expect(instance.itemInstances.get('item-1')?.setData).toHaveBeenCalledWith(
+      {}
+    )
     expect(instance.triggerUpdate).toHaveBeenCalledTimes(1)
   })
 
@@ -79,6 +104,7 @@ describe('syncReusedInstance', () => {
     sync(instance, makeParams({}))
 
     expect(instance.setProjectData).not.toHaveBeenCalled()
+    expect(instance.itemInstances.get('item-1')?.setData).not.toHaveBeenCalled()
     expect(instance.triggerUpdate).not.toHaveBeenCalled()
   })
 })

--- a/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
+++ b/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
@@ -51,6 +51,7 @@ import {
   type WeaverseDataValue,
 } from './utils/pick-weaverse-data'
 import { normalizeRequestInfo } from './utils/studio-request-info'
+import { syncReusedInstance } from './utils/sync-reused-instance'
 import { ThemeTextStore } from './utils/theme-text-store'
 import { useStudio } from './utils/use-studio'
 import {
@@ -292,24 +293,27 @@ function createWeaverseInstance(
 ): WeaverseHydrogen {
   const normalizedParams = normalizeRequestInfo(params)
   if (isBrowser) {
-    // Check if the weaverse instance already exists in the window object
     window.__weaverses = window.__weaverses || {}
-    let weaverse = window.__weaverses[normalizedParams.pageId]
-    // If the weaverse instance does not exist, or the pathname or search has changed, create a new instance
-    if (
-      !weaverse ||
-      weaverse?.requestInfo?.pathname !==
-        normalizedParams.requestInfo.pathname ||
-      weaverse?.requestInfo?.search !== normalizedParams.requestInfo.search
-    ) {
-      weaverse = new WeaverseHydrogen(normalizedParams)
-      window.__weaverses[normalizedParams.pageId] = weaverse
-    }
-    if (weaverse?.isDesignMode) {
+    const existing = window.__weaverses[normalizedParams.pageId]
+    // Reuse the instance only while the browser stays on the same URL —
+    // navigation to a different pathname/search builds a fresh instance.
+    const isReused =
+      existing?.requestInfo?.pathname ===
+        normalizedParams.requestInfo.pathname &&
+      existing?.requestInfo?.search === normalizedParams.requestInfo.search
+    const weaverse = isReused
+      ? existing
+      : new WeaverseHydrogen(normalizedParams)
+    window.__weaverses[normalizedParams.pageId] = weaverse
+    if (weaverse.isDesignMode) {
       weaverse.requestInfo = normalizedParams.requestInfo
       if (hasWeaverseStudio(window)) {
         window.weaverseStudio.refreshStudio(normalizedParams)
       }
+    } else if (isReused) {
+      // Same-URL revalidation in live/preview mode: the reused instance
+      // must adopt the fresh loader payload (see syncReusedInstance).
+      syncReusedInstance(weaverse, normalizedParams)
     }
     return weaverse
   }

--- a/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
+++ b/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
@@ -50,7 +50,7 @@ import {
   pickWeaverseData,
   type WeaverseDataValue,
 } from './utils/pick-weaverse-data'
-import { normalizeDesignModeRequestInfo } from './utils/studio-request-info'
+import { normalizeRequestInfo } from './utils/studio-request-info'
 import { ThemeTextStore } from './utils/theme-text-store'
 import { useStudio } from './utils/use-studio'
 import {
@@ -290,7 +290,7 @@ export class WeaverseHydrogen extends Weaverse {
 function createWeaverseInstance(
   params: WeaverseHydrogenParams
 ): WeaverseHydrogen {
-  const normalizedParams = normalizeDesignModeRequestInfo(params)
+  const normalizedParams = normalizeRequestInfo(params)
   if (isBrowser) {
     // Check if the weaverse instance already exists in the window object
     window.__weaverses = window.__weaverses || {}

--- a/packages/hydrogen/src/utils/studio-request-info.ts
+++ b/packages/hydrogen/src/utils/studio-request-info.ts
@@ -30,17 +30,19 @@ function getQueriesFromSearch(
 }
 
 /**
- * React Router v7 single-fetch revalidation can render client data returned from
- * a `/_root.data` request while the browser is still on the merchant-facing
- * preview URL. In design mode, Studio instance identity must follow the browser
- * URL, not the transient data endpoint, otherwise the SDK creates a fresh
- * Weaverse instance without the existing Studio bridge/interactions attached.
+ * React Router v7 single-fetch revalidation can render client data returned
+ * from a `*.data` request while the browser is still on the canonical URL.
+ * Instance identity must follow the browser URL, not the transient data
+ * endpoint, otherwise the SDK creates a fresh Weaverse instance mid-session:
+ * in design mode that drops the existing Studio bridge/interactions, and in
+ * the live theme it resets every section's runtime state after any
+ * revalidation (cart mutations, locale switches, `revalidate()`). See #451.
  */
-export function normalizeDesignModeRequestInfo(
+export function normalizeRequestInfo(
   params: WeaverseHydrogenParams,
   browserLocation: BrowserLocationLike | undefined = getBrowserLocation()
 ): WeaverseHydrogenParams {
-  if (!(params.isDesignMode && browserLocation)) {
+  if (!browserLocation) {
     return params
   }
 

--- a/packages/hydrogen/src/utils/sync-reused-instance.ts
+++ b/packages/hydrogen/src/utils/sync-reused-instance.ts
@@ -1,0 +1,45 @@
+import type { WeaverseHydrogenParams } from '../types'
+import type { WeaverseHydrogen } from '../WeaverseHydrogenRoot'
+
+/**
+ * Apply a fresh loader payload to a reused Weaverse instance.
+ *
+ * With requestInfo normalized to the browser URL, same-URL revalidations
+ * (cart mutations, `useRevalidator()`, locale-neutral re-fetches) reuse the
+ * cached `window.__weaverses[pageId]` instance instead of constructing a new
+ * one — which preserves section state, but would silently drop the fresh
+ * `data`/`dataContext` the loaders just returned. Sync them here.
+ *
+ * Design mode is excluded by the caller: Studio owns the instance data there
+ * (unsaved drafts must not be clobbered) and applies updates via
+ * `refreshStudio` instead.
+ *
+ * Change detection uses JSON comparison — loader payloads are
+ * wire-serialized, so key order is stable between runs; a false mismatch
+ * only costs one extra re-render.
+ */
+export function syncReusedInstance(
+  weaverse: WeaverseHydrogen,
+  params: WeaverseHydrogenParams
+) {
+  weaverse.requestInfo = params.requestInfo
+  weaverse.internal = params.internal
+
+  let dataChanged =
+    JSON.stringify(weaverse.data) !== JSON.stringify(params.data)
+  let contextChanged =
+    JSON.stringify(weaverse.dataContext ?? null) !==
+    JSON.stringify(params.dataContext ?? null)
+
+  if (dataChanged) {
+    // State-preserving: existing item stores receive `setData` (and emit),
+    // missing ones are created — no full instance teardown.
+    weaverse.setProjectData(params.data)
+  }
+  if (contextChanged) {
+    weaverse.dataContext = params.dataContext ?? null
+  }
+  if (dataChanged || contextChanged) {
+    weaverse.triggerUpdate()
+  }
+}

--- a/packages/hydrogen/src/utils/sync-reused-instance.ts
+++ b/packages/hydrogen/src/utils/sync-reused-instance.ts
@@ -31,13 +31,25 @@ export function syncReusedInstance(
     JSON.stringify(weaverse.dataContext ?? null) !==
     JSON.stringify(params.dataContext ?? null)
 
+  if (contextChanged) {
+    // Assign before notifying any item store: components resolve data
+    // connectors against `weaverse.dataContext` at render time, so the
+    // fresh context must be in place when re-renders flush.
+    weaverse.dataContext = params.dataContext ?? null
+  }
   if (dataChanged) {
     // State-preserving: existing item stores receive `setData` (and emit),
     // missing ones are created — no full instance teardown.
     weaverse.setProjectData(params.data)
-  }
-  if (contextChanged) {
-    weaverse.dataContext = params.dataContext ?? null
+  } else if (contextChanged) {
+    // Context-only change: memoized item components subscribe to their item
+    // store snapshot, and snapshot identity follows the `_store` reference —
+    // a bare `triggerUpdate()` would notify with an identical snapshot and
+    // `useSyncExternalStore` would skip the re-render. `setData({})` swaps
+    // the store reference so connectors re-resolve against the new context.
+    for (const { id } of params.data?.items || []) {
+      weaverse.itemInstances.get(id)?.setData({})
+    }
   }
   if (dataChanged || contextChanged) {
     weaverse.triggerUpdate()

--- a/packages/hydrogen/src/utils/use-studio.ts
+++ b/packages/hydrogen/src/utils/use-studio.ts
@@ -11,6 +11,32 @@ import { hasWeaverseStudio } from '~/types'
 import { useThemeText } from '../hooks/theme-text-context'
 import { useThemeSettingsStore } from './use-theme-settings-store'
 
+const STUDIO_READY_POLL_MS = 50
+const STUDIO_READY_TIMEOUT_MS = 5000
+
+/**
+ * Resolve once `window.weaverseStudio` is available, or `null` on timeout.
+ * The studio script sets the global when it *executes*; `loadScript` can
+ * resolve earlier for tags it did not create (e.g. SSR-injected markup),
+ * so never assume readiness right after the script promise settles.
+ */
+function waitForStudio(): Promise<Window['weaverseStudio'] | null> {
+  return new Promise((resolve) => {
+    let startedAt = Date.now()
+    function check() {
+      if (hasWeaverseStudio(window)) {
+        return resolve(window.weaverseStudio)
+      }
+      if (Date.now() - startedAt >= STUDIO_READY_TIMEOUT_MS) {
+        console.warn('[Weaverse] Studio script did not initialize in time')
+        return resolve(null)
+      }
+      setTimeout(check, STUDIO_READY_POLL_MS)
+    }
+    check()
+  })
+}
+
 export function useStudio(weaverse: WeaverseHydrogen) {
   let { revalidate } = useRevalidator()
   let navigation = useNavigation()
@@ -43,11 +69,8 @@ export function useStudio(weaverse: WeaverseHydrogen) {
         }
         let studioSrc = `${weaverseHost}/static/studio/hydrogen/index.js?v=${weaverseVersion}`
         loadScript(studioSrc)
-          .then(() => {
-            if (hasWeaverseStudio(window)) {
-              window.weaverseStudio.init(weaverse)
-            }
-          })
+          .then(waitForStudio)
+          .then((studio) => studio?.init(weaverse))
           .catch(console.error)
       }
     }


### PR DESCRIPTION
Part of Weaverse/weaverse#500 (SDK side — layers 3a/3-readiness/2-live from the [root-cause analysis](https://github.com/Weaverse/weaverse/issues/451#issuecomment-4667868077)). The Builder-side `init()` pageId negotiation ships separately in Weaverse/builder.

## What changed

1. **`@weaverse/core` `loadScript`** — caches one promise per `src` so concurrent callers resolve only after the script *executes*, not when its tag merely exists. Previously, with two `<WeaverseContent/>` instances mounting in one commit (nested layout + child), the second `StudioBridge`'s `loadScript` resolved before the studio script ran, `hasWeaverseStudio(window)` was false, and that instance was silently never registered with Studio. On error the cache entry and broken tag are removed so retries work.

2. **`use-studio.ts`** — replaces the silent `if (hasWeaverseStudio(window))` skip with `waitForStudio()` (50ms poll, 5s timeout), so `init` is never dropped when the script hasn't executed yet (e.g. SSR-injected or externally added tags that bypass the promise cache).

3. **`studio-request-info.ts`** — `normalizeDesignModeRequestInfo` → `normalizeRequestInfo`: requestInfo now normalizes to the browser URL in **all** modes, not just design mode. Live-theme revalidations (cart mutations, `revalidate()`) deliver loader-derived requestInfo with single-fetch artifacts; the pathname/search mismatch in `createWeaverseInstance` then built a fresh instance mid-session, resetting every section's runtime state. SSR behavior unchanged (no browser location → params pass through).

## Tests

- `packages/core/__tests__/load-script.test.ts` (new): shared in-flight promise resolves only after `onload`; pre-existing external tags still resolve immediately; error clears cache + tag and allows retry. Also wired `@weaverse/core` into the turbo `test` pipeline.
- `packages/hydrogen/__tests__/studio-request-info.test.ts`: updated for all-mode normalization + no-op identity case + SSR pass-through.

`pnpm run biome` / `typecheck` / `test` all green (33 tests in touched files; full suite unaffected).