### PR TITLE
perf: normalize loadPage URL to stop tracking-param cache fragmentation

### DIFF
--- a/packages/hydrogen/__tests__/normalize-page-url.test.ts
+++ b/packages/hydrogen/__tests__/normalize-page-url.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { normalizePageUrl } from '../src/utils/normalize-page-url'
+
+describe('normalizePageUrl', () => {
+  it('should_strip_tracking_params_so_equivalent_urls_share_one_cache_key', () => {
+    const plain = normalizePageUrl('https://shop.com/products/shirt')
+    const tracked = normalizePageUrl(
+      'https://shop.com/products/shirt?utm_source=fb&utm_campaign=x&fbclid=abc123&gclid=z'
+    )
+
+    expect(tracked).toBe(plain)
+    expect(plain).toBe('https://shop.com/products/shirt')
+  })
+
+  it('should_keep_weaverse_control_params_and_sort_them', () => {
+    const normalized = normalizePageUrl(
+      'https://shop.com/?weaverseHost=https%3A%2F%2Fstudio.weaverse.io&utm_source=fb&isDesignMode=true&__revisionId=rev-1'
+    )
+
+    expect(normalized).toBe(
+      'https://shop.com/?__revisionId=rev-1&isDesignMode=true&weaverseHost=https%3A%2F%2Fstudio.weaverse.io'
+    )
+  })
+
+  it('should_produce_identical_keys_regardless_of_param_order', () => {
+    const a = normalizePageUrl(
+      'https://shop.com/help?isDesignMode=true&__revisionId=r1'
+    )
+    const b = normalizePageUrl(
+      'https://shop.com/help?__revisionId=r1&isDesignMode=true'
+    )
+
+    expect(a).toBe(b)
+  })
+
+  it('should_preserve_pathname_used_for_handle_resolution', () => {
+    expect(normalizePageUrl('https://shop.com/help/contact?sort=asc')).toBe(
+      'https://shop.com/help/contact'
+    )
+  })
+
+  it('should_return_input_unchanged_when_not_an_absolute_url', () => {
+    expect(normalizePageUrl('/relative/path?x=1')).toBe('/relative/path?x=1')
+  })
+})

--- a/packages/hydrogen/src/utils/normalize-page-url.ts
+++ b/packages/hydrogen/src/utils/normalize-page-url.ts
@@ -1,0 +1,35 @@
+// Query params that influence Weaverse page resolution on the Builder:
+// revision previews, design-mode flags, and `weaverse*` control params
+// (host, version, project id). Everything else — utm_*, fbclid, gclid,
+// storefront filters — is irrelevant to which page the Builder returns.
+const KEPT_PARAM_RE = /^(?:__revisionId|isDesignMode|weaverse)/
+
+/**
+ * Normalize the storefront URL sent in the Builder page API request body.
+ *
+ * The POST body participates in the `withCache` cache key, so a raw
+ * `request.url` fragments the cache by every marketing/tracking param:
+ * each distinct `?utm_…`/`fbclid` URL is a guaranteed Builder round-trip
+ * even when the resolved page is identical — precisely the paid/social
+ * traffic that needs the cache most (builder#2450).
+ *
+ * The Builder reads only the pathname (locale/type/handle fallback) and
+ * the params matched above from this URL, so keep exactly those. Params
+ * are sorted for a stable cache key regardless of their order in the
+ * incoming URL.
+ */
+export function normalizePageUrl(url: string): string {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    // Not an absolute URL (shouldn't happen for request.url) — send as-is.
+    return url
+  }
+  const kept = [...parsed.searchParams].filter(([key]) =>
+    KEPT_PARAM_RE.test(key)
+  )
+  kept.sort(([a], [b]) => a.localeCompare(b))
+  const search = new URLSearchParams(kept).toString()
+  return `${parsed.origin}${parsed.pathname}${search ? `?${search}` : ''}`
+}

--- a/packages/hydrogen/src/weaverse-client.ts
+++ b/packages/hydrogen/src/weaverse-client.ts
@@ -34,6 +34,7 @@ import {
   getRequestQueries,
   getWeaverseConfigs,
 } from './utils'
+import { normalizePageUrl } from './utils/normalize-page-url'
 
 /**
  * Cache duration constants (in seconds).
@@ -926,7 +927,9 @@ export class WeaverseClient {
         ...basePageRequestBody,
         projectId: effectiveProjectId, // Use effective (potentially overridden) projectId
         params: pageLoadParams,
-        url: request.url,
+        // Stripped to pathname + Weaverse params — tracking params would
+        // fragment the subrequest cache key (see normalizePageUrl).
+        url: normalizePageUrl(request.url),
       }
 
       const reqInit: RequestInit = {


### PR DESCRIPTION
Item 4 from the [Weaverse/builder#2450 investigation](https://github.com/Weaverse/builder/issues/2450#issuecomment-4668232032).

## Problem

`loadPage` sends the raw `request.url` in the Builder POST body, and the body participates in the `withCache` subrequest cache key. Every distinct `?utm_source=…`/`fbclid=…`/`gclid=…` URL therefore bypasses the Oxygen-side cache and round-trips to the Builder, even though the resolved page is identical — and paid/social traffic (the traffic that most needs fast TTFB) is precisely the traffic carrying those params. With the new 300s shared freshness from #456 this was the single biggest remaining hit-rate lever.

## Change

`normalizePageUrl()` (new util) keeps only what the Builder actually reads from this URL — verified against `parseAssignmentParams` and the `/api/public/project` handler:

- **pathname** — locale/type/handle fallback resolution
- **`__revisionId`** — revision previews
- **`isDesignMode`** + **`weaverse*`** params — design-mode control

Everything else is dropped; kept params are sorted so param order can't fragment the key either. Non-absolute URLs pass through unchanged. The error-logging path keeps the raw URL for debuggability.

## Tests

`normalize-page-url.test.ts` (5): tracked and untracked URLs collapse to one key; weaverse params preserved + sorted; order-independence; pathname preserved; non-absolute passthrough. Full `weaverse-client` suite still green (30 tests total), typecheck + biome clean.