### PR TITLE
perf: memoize render-path work in item renderer and root

### DIFF
--- a/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
+++ b/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
@@ -341,13 +341,14 @@ function RenderRoot(props: {
   const { data, components, dataContext } = props
   if (!registeredComponentLists.has(components)) {
     for (const comp of [...components, ...defaultComponents]) {
-      comp?.schema?.type &&
+      if (comp?.schema?.type) {
         registerComponent({
-          type: comp?.schema.type,
+          type: comp.schema.type,
           Component: comp.default,
           schema: comp.schema,
           loader: comp.loader,
         })
+      }
     }
     registeredComponentLists.add(components)
   }

--- a/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
+++ b/packages/hydrogen/src/WeaverseHydrogenRoot.tsx
@@ -325,20 +325,31 @@ const StudioBridge = memo(({ context }: { context: WeaverseHydrogen }) => {
   return null
 })
 
+/**
+ * Component lists already pushed into the element registry. Registration is
+ * idempotent (the registry checks `has(type)`), but walking the full list
+ * allocates and loops on every render — theme component arrays are
+ * module-level constants, so register each list identity once.
+ */
+const registeredComponentLists = new WeakSet<HydrogenComponent[]>()
+
 function RenderRoot(props: {
   data: WeaverseLoaderData
   components: HydrogenComponent[]
   dataContext?: Record<string, any>
 }) {
   const { data, components, dataContext } = props
-  for (const comp of [...components, ...defaultComponents]) {
-    comp?.schema?.type &&
-      registerComponent({
-        type: comp?.schema.type,
-        Component: comp.default,
-        schema: comp.schema,
-        loader: comp.loader,
-      })
+  if (!registeredComponentLists.has(components)) {
+    for (const comp of [...components, ...defaultComponents]) {
+      comp?.schema?.type &&
+        registerComponent({
+          type: comp?.schema.type,
+          Component: comp.default,
+          schema: comp.schema,
+          loader: comp.loader,
+        })
+    }
+    registeredComponentLists.add(components)
   }
   const { page, configs, project, pageAssignment } = data || {}
 
@@ -412,8 +423,12 @@ export const WeaverseHydrogenRoot = memo(
     const matches = useMatches()
 
     // Flat route-keyed data context for data-connector template resolution
-    // (e.g. {{root.layout.shop.name}}). Legitimately needs all matches.
-    const enhancedDataContext = createWeaverseDataContext(matches)
+    // (e.g. {{root.layout.shop.name}}). Legitimately needs all matches;
+    // memoized so same-matches re-renders don't allocate a fresh context.
+    const enhancedDataContext = useMemo(
+      () => createWeaverseDataContext(matches),
+      [matches]
+    )
 
     // Route-scoped weaverseData lookup. `useLoaderData()` returns the
     // closest route's loader data, which is what makes nested layout +

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -1,6 +1,6 @@
 import type { Weaverse } from '@weaverse/core'
 import clsx from 'clsx'
-import React, { memo, useEffect, useRef } from 'react'
+import React, { memo, useEffect, useMemo, useRef } from 'react'
 import { useItemInstance, useWeaverse } from '~/hooks'
 import { WeaverseContextProvider, WeaverseItemContext } from './context'
 import type { ItemComponentProps, WeaverseRootPropsType } from './types'
@@ -110,9 +110,15 @@ const ItemComponent = memo(({ instance }: ItemComponentProps) => {
 
   // Replace data connectors in all component data (handles strings, objects, and arrays recursively)
   // IMMUTABLE: Process the entire rest object to avoid mutating original content
-  const processedRest = replaceContentDataConnectorsDeep(
-    rest,
-    context.dataContext
+  // Memoized per snapshot: `data` identity changes exactly when the item's
+  // store or translation entry changes (see WeaverseHydrogenItem.getSnapShot),
+  // and context-only updates swap the store reference via `setData({})` in
+  // syncReusedInstance — so re-renders with an unchanged snapshot skip the
+  // deep placeholder scan + clone entirely.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `rest` is a pure projection of `data`
+  const processedRest = useMemo(
+    () => replaceContentDataConnectorsDeep(rest, context.dataContext),
+    [data, context.dataContext]
   )
 
   useEffect(() => {
@@ -132,7 +138,10 @@ const ItemComponent = memo(({ instance }: ItemComponentProps) => {
 
   if (Element?.Component) {
     const Component = Element.Component
-    Component.displayName = type
+    if (Component.displayName !== type) {
+      // Devtools nicety — assign once, not on every render.
+      Component.displayName = type
+    }
     if (
       Component.$$typeof === Symbol.for('react.forward_ref') ||
       reactVersion > REACT_VERSION_THRESHOLD


### PR DESCRIPTION
Three render-mechanism costs eliminated, none behavior-changing:

- ItemComponent re-ran replaceContentDataConnectorsDeep on every render
  of every item — a deep placeholder scan (plus deep clone when
  connectors exist) over the full item data including loaderData
  payloads (~0.5ms per full-page re-render pass with realistic
  product-section data on M4, ~5x that on low-end mobile). Now memoized
  per snapshot: getSnapShot() is identity-stable, and context-only
  updates already swap the store reference via setData({}) in
  syncReusedInstance, so [data, context.dataContext] is a sufficient
  dependency key.

- RenderRoot walked and re-registered the full component list on every
  render; registration is idempotent but the spread + loop ran each
  time. Component arrays are module-level constants — register each
  list identity once via WeakSet.

- WeaverseHydrogenRoot rebuilt the route-keyed data context object on
  every render; now memoized on matches. Component.displayName is also
  assigned only when it actually changes instead of every render.
