### PR TITLE
add public API base for edge cache proxy

### DIFF
--- a/packages/hydrogen/__tests__/weaverse-client.test.ts
+++ b/packages/hydrogen/__tests__/weaverse-client.test.ts
@@ -369,6 +369,40 @@ describe('WeaverseClient Multi-Project Architecture', () => {
       expect(directFetch).toHaveBeenCalledTimes(1)
       expect(fetchWithCache).not.toHaveBeenCalled()
     })
+
+    it('should bypass shared cache for external public API proxy', async () => {
+      let weaverse = new WeaverseClient({
+        ...createMockContext({
+          env: {
+            WEAVERSE_PROJECT_ID: 'project-abc',
+            WEAVERSE_HOST: 'https://studio.weaverse.io',
+            WEAVERSE_PUBLIC_API_BASE: 'https://api.weaverse.io',
+          },
+        }),
+        components: mockComponents,
+        themeSchema: mockThemeSchema,
+      })
+      let fetchWithCache = mock(async () => ({
+        data: { ok: true },
+        response: new Response('{}'),
+      }))
+      let directFetch = mock(async () => ({
+        data: { ok: true },
+        response: new Response('{}'),
+      }))
+      weaverse.withCache.fetch = fetchWithCache
+      ;(weaverse as any).directFetch = directFetch
+
+      await weaverse.fetchWithCache(
+        'https://api.weaverse.io/api/public/project',
+        { cacheTarget: 'project' as any }
+      )
+
+      expect(weaverse.configs.weaverseHost).toBe('https://studio.weaverse.io')
+      expect(weaverse.configs.weaverseApiBase).toBe('https://api.weaverse.io')
+      expect(directFetch).toHaveBeenCalledTimes(1)
+      expect(fetchWithCache).not.toHaveBeenCalled()
+    })
   })
 
   describe('T032: Route-Level Override', () => {

--- a/packages/hydrogen/__tests__/weaverse-configs.test.ts
+++ b/packages/hydrogen/__tests__/weaverse-configs.test.ts
@@ -51,6 +51,21 @@ describe('getWeaverseConfigs', () => {
     expect(configs.weaverseApiBase).toBe('https://api.weaverse.io')
   })
 
+  it('should_fall_back_to_custom_weaverse_host_when_no_public_api_base', () => {
+    let configs = getWeaverseConfigs(
+      new Request('https://example.com/products/blue-shirt'),
+      {
+        WEAVERSE_HOST: 'https://staging.self-hosted.example.com',
+        WEAVERSE_PROJECT_ID: 'project-1',
+      } as unknown as HydrogenEnv
+    )
+
+    expect(configs.weaverseHost).toBe('https://staging.self-hosted.example.com')
+    expect(configs.weaverseApiBase).toBe(
+      'https://staging.self-hosted.example.com'
+    )
+  })
+
   it('should_keep_editor_host_overrides_ahead_of_public_api_base', () => {
     let request = new Request(
       'https://example.com/products/blue-shirt?weaverseHost=https://preview.weaverse.io'

--- a/packages/hydrogen/__tests__/weaverse-configs.test.ts
+++ b/packages/hydrogen/__tests__/weaverse-configs.test.ts
@@ -34,21 +34,35 @@ describe('getWeaverseConfigs', () => {
 
     expect(configs.weaverseApiBase).toBe('https://studio.weaverse.io')
   })
+
+  it('should_use_public_api_base_when_configured', () => {
+    let configs = getWeaverseConfigs(
+      new Request('https://example.com/products/blue-shirt'),
+      {
+        WEAVERSE_HOST: 'https://studio.weaverse.io',
+        WEAVERSE_PUBLIC_API_BASE: 'https://api.weaverse.io',
+        WEAVERSE_PROJECT_ID: 'project-1',
+      } as unknown as HydrogenEnv
+    )
+
+    expect(configs.weaverseHost).toBe('https://studio.weaverse.io')
+    expect(configs.weaverseApiBase).toBe('https://api.weaverse.io')
+  })
 })
 
 describe('WeaverseClient API URLs', () => {
-  it('should_build_api_urls_from_studio_host', () => {
+  it('should_build_api_urls_from_public_api_base', () => {
     let client = Object.create(
       WeaverseClient.prototype
     ) as ClientWithPrivateApiUrl
     client.configs = {
       projectId: 'project-1',
-      weaverseApiBase: 'https://legacy-api.example.com',
+      weaverseApiBase: 'https://api.weaverse.io',
       weaverseHost: 'https://studio.weaverse.io',
     }
 
     let url = client.getApiUrl('project_configs')
 
-    expect(url).toBe('https://studio.weaverse.io/api/public/project_configs')
+    expect(url).toBe('https://api.weaverse.io/api/public/project_configs')
   })
 })

--- a/packages/hydrogen/__tests__/weaverse-configs.test.ts
+++ b/packages/hydrogen/__tests__/weaverse-configs.test.ts
@@ -13,13 +13,14 @@ interface ClientWithPrivateApiUrl {
 }
 
 describe('getWeaverseConfigs', () => {
-  it('should_default_api_base_to_studio_host', () => {
+  it('should_default_api_base_to_edge_proxy', () => {
     let configs = getWeaverseConfigs(
       new Request('https://example.com/products/blue-shirt'),
       { WEAVERSE_PROJECT_ID: 'project-1' } as unknown as HydrogenEnv
     )
 
-    expect(configs.weaverseApiBase).toBe('https://studio.weaverse.io')
+    expect(configs.weaverseHost).toBe('https://studio.weaverse.io')
+    expect(configs.weaverseApiBase).toBe('https://api.weaverse.io')
   })
 
   it('should_ignore_legacy_api_base_when_studio_host_is_configured', () => {
@@ -32,7 +33,8 @@ describe('getWeaverseConfigs', () => {
       } as unknown as HydrogenEnv
     )
 
-    expect(configs.weaverseApiBase).toBe('https://studio.weaverse.io')
+    expect(configs.weaverseHost).toBe('https://studio.weaverse.io')
+    expect(configs.weaverseApiBase).toBe('https://api.weaverse.io')
   })
 
   it('should_use_public_api_base_when_configured', () => {

--- a/packages/hydrogen/__tests__/weaverse-configs.test.ts
+++ b/packages/hydrogen/__tests__/weaverse-configs.test.ts
@@ -48,6 +48,20 @@ describe('getWeaverseConfigs', () => {
     expect(configs.weaverseHost).toBe('https://studio.weaverse.io')
     expect(configs.weaverseApiBase).toBe('https://api.weaverse.io')
   })
+
+  it('should_keep_editor_host_overrides_ahead_of_public_api_base', () => {
+    let request = new Request(
+      'https://example.com/products/blue-shirt?weaverseHost=https://preview.weaverse.io'
+    )
+    let configs = getWeaverseConfigs(request, {
+      WEAVERSE_HOST: 'https://studio.weaverse.io',
+      WEAVERSE_PUBLIC_API_BASE: 'https://api.weaverse.io',
+      WEAVERSE_PROJECT_ID: 'project-1',
+    } as unknown as HydrogenEnv)
+
+    expect(configs.weaverseHost).toBe('https://preview.weaverse.io')
+    expect(configs.weaverseApiBase).toBe('https://preview.weaverse.io')
+  })
 })
 
 describe('WeaverseClient API URLs', () => {

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -150,6 +150,12 @@ export interface WeaverseHydrogenParams
   weaverseApiBase: string
   weaverseApiKey: string
   weaverseHost: string
+  /**
+   * Public data API origin. Keep `weaverseHost` for Studio scripts/editor
+   * assets; point this at the Cloudflare proxy (`https://api.weaverse.io`)
+   * when edge caching is enabled.
+   */
+  weaversePublicApiBase?: string
   weaverseVersion?: string
 }
 
@@ -179,6 +185,7 @@ export type WeaverseProjectConfigs = {
   projectId: string
   weaverseHost: string
   weaverseApiBase: string
+  weaversePublicApiBase?: string
   weaverseApiKey: string
   weaverseVersion?: string
   isDesignMode?: boolean
@@ -635,6 +642,7 @@ declare module '@shopify/hydrogen' {
     WEAVERSE_API_KEY: string
     WEAVERSE_HOST?: string
     WEAVERSE_PROJECT_ID: string
+    WEAVERSE_PUBLIC_API_BASE?: string
   }
 }
 

--- a/packages/hydrogen/src/utils/index.ts
+++ b/packages/hydrogen/src/utils/index.ts
@@ -114,16 +114,20 @@ export function getWeaverseConfigs(
 
   let url = new URL(request.url)
   let isRevisionPreview = url.searchParams.has('__revisionId')
+  let configuredWeaverseHost = WEAVERSE_HOST || envFromProcess.WEAVERSE_HOST
   let resolvedWeaverseHost =
-    weaverseHost ||
-    WEAVERSE_HOST ||
-    envFromProcess.WEAVERSE_HOST ||
-    'https://studio.weaverse.io'
+    weaverseHost || configuredWeaverseHost || 'https://studio.weaverse.io'
+  // Public data reads default to the edge proxy, but an explicit custom
+  // WEAVERSE_HOST (staging/self-hosted Weaverse) must stay the API base so
+  // those deployments don't fetch page/config data from the production proxy.
   let resolvedWeaverseApiBase = weaverseHost
     ? weaverseHost
     : WEAVERSE_PUBLIC_API_BASE ||
       envFromProcess.WEAVERSE_PUBLIC_API_BASE ||
-      'https://api.weaverse.io'
+      (configuredWeaverseHost &&
+      configuredWeaverseHost !== 'https://studio.weaverse.io'
+        ? configuredWeaverseHost
+        : 'https://api.weaverse.io')
 
   return {
     projectId:

--- a/packages/hydrogen/src/utils/index.ts
+++ b/packages/hydrogen/src/utils/index.ts
@@ -123,7 +123,7 @@ export function getWeaverseConfigs(
     ? weaverseHost
     : WEAVERSE_PUBLIC_API_BASE ||
       envFromProcess.WEAVERSE_PUBLIC_API_BASE ||
-      resolvedWeaverseHost
+      'https://api.weaverse.io'
 
   return {
     projectId:

--- a/packages/hydrogen/src/utils/index.ts
+++ b/packages/hydrogen/src/utils/index.ts
@@ -97,6 +97,7 @@ export function getWeaverseConfigs(
     WEAVERSE_PROJECT_ID,
     WEAVERSE_API_KEY,
     WEAVERSE_HOST,
+    WEAVERSE_PUBLIC_API_BASE,
     PUBLIC_STORE_DOMAIN,
     PUBLIC_STOREFRONT_API_TOKEN,
   } = env || {}
@@ -118,6 +119,10 @@ export function getWeaverseConfigs(
     WEAVERSE_HOST ||
     envFromProcess.WEAVERSE_HOST ||
     'https://studio.weaverse.io'
+  let resolvedWeaverseApiBase =
+    WEAVERSE_PUBLIC_API_BASE ||
+    envFromProcess.WEAVERSE_PUBLIC_API_BASE ||
+    resolvedWeaverseHost
 
   return {
     projectId:
@@ -126,7 +131,8 @@ export function getWeaverseConfigs(
       envFromProcess.WEAVERSE_PROJECT_ID ||
       '',
     weaverseHost: resolvedWeaverseHost,
-    weaverseApiBase: resolvedWeaverseHost,
+    weaverseApiBase: resolvedWeaverseApiBase,
+    weaversePublicApiBase: resolvedWeaverseApiBase,
     weaverseApiKey:
       weaverseApiKey ||
       WEAVERSE_API_KEY ||

--- a/packages/hydrogen/src/utils/index.ts
+++ b/packages/hydrogen/src/utils/index.ts
@@ -119,10 +119,11 @@ export function getWeaverseConfigs(
     WEAVERSE_HOST ||
     envFromProcess.WEAVERSE_HOST ||
     'https://studio.weaverse.io'
-  let resolvedWeaverseApiBase =
-    WEAVERSE_PUBLIC_API_BASE ||
-    envFromProcess.WEAVERSE_PUBLIC_API_BASE ||
-    resolvedWeaverseHost
+  let resolvedWeaverseApiBase = weaverseHost
+    ? weaverseHost
+    : WEAVERSE_PUBLIC_API_BASE ||
+      envFromProcess.WEAVERSE_PUBLIC_API_BASE ||
+      resolvedWeaverseHost
 
   return {
     projectId:

--- a/packages/hydrogen/src/weaverse-client.ts
+++ b/packages/hydrogen/src/weaverse-client.ts
@@ -510,8 +510,16 @@ export class WeaverseClient {
 
   // Helper method for building API URLs consistently
   private getApiUrl(endpoint: string): string {
-    const { weaverseHost } = this.configs
-    return `${weaverseHost}/api/public/${endpoint}`
+    const { weaverseApiBase } = this.configs
+    return `${weaverseApiBase}/api/public/${endpoint}`
+  }
+
+  private isExternalPublicApiUrl(url: string): boolean {
+    const { weaverseApiBase, weaverseHost } = this.configs
+    return (
+      weaverseApiBase !== weaverseHost &&
+      url.startsWith(`${weaverseApiBase}/api/public/`)
+    )
   }
 
   /**
@@ -560,10 +568,16 @@ export class WeaverseClient {
 
     let result: WithCacheFetchResponse<T>
 
-    // Bypass the shared cache for design mode and revision previews:
-    // both must always reflect the latest Builder state, and caching
-    // one-off revision responses would only pollute the cache.
-    if (this.configs.isDesignMode || this.configs.isRevisionPreview) {
+    // Bypass the shared Hydrogen subrequest cache for design/revision modes
+    // and for the Cloudflare public API proxy. The proxy owns freshness with
+    // versioned cache keys; keeping Hydrogen's URL/body cache in front would
+    // keep serving a stale response even after Builder bumps api.weaverse.io's
+    // project version.
+    if (
+      this.configs.isDesignMode ||
+      this.configs.isRevisionPreview ||
+      this.isExternalPublicApiUrl(url)
+    ) {
       result = await this.directFetch<T>(url, fetchOptions)
     } else {
       // Use withCache.fetch for better integration with Hydrogen's caching system

--- a/packages/hydrogen/src/weaverse-client.ts
+++ b/packages/hydrogen/src/weaverse-client.ts
@@ -806,7 +806,7 @@ export class WeaverseClient {
     locale?: string
     limit?: number
   }): Promise<CustomPageEntry[]> {
-    const { weaverseHost, projectId } = this.configs
+    const { weaverseApiBase, projectId } = this.configs
     const entries: CustomPageEntry[] = []
     const MAX_PAGES = 100
 
@@ -825,7 +825,7 @@ export class WeaverseClient {
       }
 
       const qs = params.toString()
-      const url = `${weaverseHost}/api/public/v1/projects/${projectId}/custom-pages${qs ? `?${qs}` : ''}`
+      const url = `${weaverseApiBase}/api/public/v1/projects/${projectId}/custom-pages${qs ? `?${qs}` : ''}`
 
       try {
         const result = await this.fetchWithCache<{

--- a/packages/hydrogen/test/weaverse-client-custom-pages.test.ts
+++ b/packages/hydrogen/test/weaverse-client-custom-pages.test.ts
@@ -9,6 +9,7 @@ type ApiResponse = { data: CustomPageEntry[]; nextCursor: string | null }
 function makeClient(fetchImpl: (url: string) => Promise<Response>) {
   return {
     configs: {
+      weaverseApiBase: 'https://cdn.weaverse.io',
       weaverseHost: 'https://builder.weaverse.io',
       projectId: 'test-project-id',
     },
@@ -85,6 +86,19 @@ describe('fetchCustomPages', () => {
     })
     await fetchPages(client, { locale: 'fr' })
     expect(capturedUrl).toContain('locale=fr')
+  })
+
+  it('uses public api base instead of studio host when configured', async () => {
+    let capturedUrl = ''
+    const client = makeClient((url) => {
+      capturedUrl = url
+      return Promise.resolve(Response.json({ data: [], nextCursor: null }))
+    })
+    await fetchPages(client)
+    expect(capturedUrl.startsWith('https://cdn.weaverse.io/api/public/')).toBe(
+      true
+    )
+    expect(capturedUrl.includes('https://builder.weaverse.io')).toBe(false)
   })
 
   it('returns accumulated entries when later page fails', async () => {

--- a/packages/hydrogen/test/weaverse-client-custom-pages.test.ts
+++ b/packages/hydrogen/test/weaverse-client-custom-pages.test.ts
@@ -95,10 +95,9 @@ describe('fetchCustomPages', () => {
       return Promise.resolve(Response.json({ data: [], nextCursor: null }))
     })
     await fetchPages(client)
-    expect(capturedUrl.startsWith('https://cdn.weaverse.io/api/public/')).toBe(
-      true
-    )
-    expect(capturedUrl.includes('https://builder.weaverse.io')).toBe(false)
+    const parsed = new URL(capturedUrl)
+    expect(parsed.origin).toBe('https://cdn.weaverse.io')
+    expect(parsed.pathname.startsWith('/api/public/')).toBe(true)
   })
 
   it('returns accumulated entries when later page fails', async () => {


### PR DESCRIPTION
Adds SDK support for splitting the public data API host from the Studio/script host.

Behavior:
- new env/config support: `WEAVERSE_PUBLIC_API_BASE`
- `getWeaverseConfigs()` resolves:
  - `weaverseHost` → Studio/editor host (`https://studio.weaverse.io`)
  - `weaverseApiBase` / `weaversePublicApiBase` → public data API host (`https://api.weaverse.io`)
- `WeaverseClient.getApiUrl()` now builds `/api/public/*` URLs from `weaverseApiBase`
- when `weaverseApiBase !== weaverseHost`, `fetchWithCache()` bypasses Hydrogen's shared subrequest cache and fetches directly: the Cloudflare proxy owns freshness with versioned cache keys, so keeping Hydrogen's URL/body cache in front would serve stale responses after Builder bumps the edge version

Verification:
- `pnpm --filter @weaverse/hydrogen test -- --run packages/hydrogen/__tests__/weaverse-configs.test.ts packages/hydrogen/__tests__/weaverse-client.test.ts`
- `pnpm --filter @weaverse/hydrogen typecheck`
- `pnpm --filter @weaverse/hydrogen build`

This intentionally leaves `weaverseHost` unchanged for Studio scripts/preview assets; only public data reads move to `api.weaverse.io`.