### PR TITLE
Add next adapter package shell

### DIFF
--- a/.weaverse/specs/2026-06-19--nextjs-adapter-contract/claude-goal-packages-next-v0.md
+++ b/.weaverse/specs/2026-06-19--nextjs-adapter-contract/claude-goal-packages-next-v0.md
@@ -1,0 +1,256 @@
+# Claude goal: implement `@weaverse/next` v0 package shell
+
+## Context
+
+Repo: `/Users/hta218/Documents/work/workspace/weaverse`
+Branch: `feat/next-adapter-shell`
+Issue: Weaverse/builder#2533
+Spec folder: `.weaverse/specs/2026-06-19--nextjs-adapter-contract/`
+
+Read these first:
+
+1. `AGENTS.md`
+2. `packages/react/AGENTS.md`
+3. `.weaverse/specs/2026-06-19--nextjs-adapter-contract/README.md`
+4. `.weaverse/specs/2026-06-19--nextjs-adapter-contract/pilot-usage-audit.md`
+5. Current APIs in:
+   - `packages/react/src/index.ts`
+   - `packages/react/src/renderer.tsx`
+   - `packages/react/src/hooks.ts`
+   - `packages/hydrogen/src/index.ts`
+   - `packages/hydrogen/src/types.ts`
+   - `packages/hydrogen/src/weaverse-client.ts`
+   - `packages/hydrogen/src/WeaverseHydrogenRoot.tsx`
+
+## Goal
+
+Implement the first small, test-backed `@weaverse/next` package slice. This is not full Shopify/Hydrogen parity. It should create a buildable package shell and prove the core adapter contract needed by Pilot:
+
+- explicit Next/native root + page data context
+- component registry + renderer bridge
+- component loader execution with explicit `commerce.storefront`
+- runtime hook re-exports for migration ergonomics
+- no dependency on `react-router` or `@shopify/remix-oxygen`
+
+## Hard constraints
+
+- Do not commit or push. Hermes will verify and commit if accepted.
+- Keep changes scoped to `packages/next` and required workspace/package metadata only.
+- Do not modify `packages/hydrogen` behavior unless absolutely unavoidable. Prefer reusing `@weaverse/react` / `@weaverse/schema` exports.
+- Do not implement production Next route handlers, Vercel deployment, cart/customer-account integration, sitemap, or CSP parity in this slice.
+- Do not read or print `.env` files.
+- Do not emulate React Router APIs (`useLoaderData`, `useRouteLoaderData`, route matches). Provide explicit Next-native data hooks instead.
+- Tests first where possible: add failing tests for the public behavior before implementation, then make them pass.
+- Keep types pragmatic. Avoid `any`; use `unknown`, interfaces, and narrow test fixtures.
+
+## Expected files
+
+Likely create:
+
+```text
+packages/next/
+  package.json
+  AGENTS.md
+  src/
+    index.ts
+    types.ts
+    client.ts
+    provider.tsx
+    renderer.tsx
+    hooks.ts
+    loader.ts
+  __tests__/
+    next-adapter.test.tsx
+```
+
+Adjust if repo conventions require a different test location.
+
+## Required public API
+
+Export at least:
+
+```ts
+export {
+  createWeaverseNextClient,
+  WeaverseNextProvider,
+  WeaverseNextRenderer,
+  runWeaverseComponentLoaders,
+  useWeaverseRootData,
+  useWeaversePageData,
+  useWeaverseCommerce,
+  useThemeSettings,
+  useParentInstance,
+  useItemInstance,
+  useChildInstances,
+  useWeaverse,
+  createSchema,
+}
+
+export type {
+  WeaverseNextClient,
+  WeaverseNextClientConfig,
+  WeaverseNextComponent,
+  WeaverseNextComponentProps,
+  WeaverseNextComponentLoaderArgs,
+  WeaverseNextLoaderData,
+  WeaverseNextRequestContext,
+  WeaverseNextCommerceContext,
+  WeaverseProduct,
+  WeaverseCollection,
+}
+```
+
+Naming can vary slightly if the implementation needs it, but keep the intent clear and update tests/spec work-log.
+
+## Implementation requirements
+
+### 1. Package shell
+
+Create `packages/next/package.json` consistent with existing packages:
+
+- name: `@weaverse/next`
+- version aligned with SDK packages (`5.16.3` currently)
+- tsup build from `src/index.ts`
+- scripts: `dev`, `build`, `clean`, `test`, `typecheck`
+- dependencies should include `@weaverse/react`, `@weaverse/schema`, `react`, `react-dom`
+- peer/optional Next dependency only if strictly needed; v0 should not require importing from `next/*`
+- must not depend on `react-router` or `@shopify/remix-oxygen`
+
+### 2. Provider + hooks
+
+Implement a provider that accepts explicit data instead of route loader emulation:
+
+```tsx
+<WeaverseNextProvider
+  client={client}
+  rootData={rootData}
+  pageData={pageData}
+  commerce={commerce}
+>
+  {children}
+</WeaverseNextProvider>
+```
+
+Provide hooks:
+
+```ts
+useWeaverseRootData<T>()
+useWeaversePageData<T>()
+useWeaverseCommerce<T>()
+```
+
+These should throw clear errors when used outside the provider.
+
+### 3. Client
+
+Implement a minimal `createWeaverseNextClient(config)` that returns an object with:
+
+- `projectId`
+- `components`
+- `themeSchema`
+- `requestContext`
+- `commerce`
+- `storefront` compatibility alias for `commerce.storefront`
+- current loaded `data` / `dataContext` enough for `@weaverse/react` renderer compatibility
+- `loadPage(input)` and `loadThemeSettings()` wrappers when fetchers are provided in config
+
+Do not guess the real Weaverse API endpoint if it is not already reusable. For this slice, it is acceptable for `loadPage` / `loadThemeSettings` to delegate to injected fetchers from config. The goal is contract shape and renderer/provider tests, not production network I/O.
+
+### 4. Renderer
+
+Implement `WeaverseNextRenderer` that can render a serialized Weaverse page tree through `@weaverse/react` primitives.
+
+Preferred approach: reuse `@weaverse/react` `WeaverseRoot` if the client shape can satisfy it. If that is too coupled to `@weaverse/core`, add a minimal bridge/client shape rather than duplicating large renderer logic.
+
+The renderer should accept either:
+
+```tsx
+<WeaverseNextRenderer />
+```
+
+using provider context, or:
+
+```tsx
+<WeaverseNextRenderer client={client} data={pageData} />
+```
+
+if that is simpler. Keep provider usage tested.
+
+### 5. Component loaders
+
+Implement `runWeaverseComponentLoaders` (or equivalent) that walks a serialized page tree and runs component `loader` functions with:
+
+```ts
+{
+  data: itemData,
+  weaverse: client,
+  context: requestContext,
+  commerce,
+}
+```
+
+Compatibility requirement:
+
+- `client.storefront` should alias `commerce.storefront` so Pilot-like loaders that call `weaverse.storefront.query(...)` can work.
+- Loader return values should be attached to the item data as `loaderData` in the shape consumed by renderer/components.
+- Walk children recursively.
+
+### 6. Re-exports
+
+Re-export:
+
+- `createSchema` and relevant schema/types from `@weaverse/schema`
+- runtime hooks from `@weaverse/react`: `useWeaverse`, `useItemInstance`, `useParentInstance`, `useChildInstances`
+- `isBrowser` / `isIframe` only if already available via `@weaverse/react` or a tiny local utility is needed by Pilot migration
+
+For `useThemeSettings`, inspect whether it is Hydrogen-specific. If it is not cleanly shared, provide a Next version backed by provider root/theme data.
+
+## Required tests
+
+Add tests proving:
+
+1. Provider hooks return explicit `rootData`, `pageData`, and `commerce`.
+2. Hooks throw clear errors outside provider.
+3. Component loader receives `commerce.storefront`, `weaverse.storefront` alias, and item `data`, then attaches `loaderData`.
+4. Renderer can render a tiny fixture tree with a registered component and child text/props.
+5. The package source does not import `react-router` or `@shopify/remix-oxygen`.
+
+Keep tests small and fast. Mock all external IO.
+
+## Verification commands to run
+
+Run the narrowest useful commands first:
+
+```sh
+pnpm --filter @weaverse/next test
+pnpm --filter @weaverse/next typecheck
+pnpm --filter @weaverse/next build
+pnpm run biome -- packages/next
+```
+
+If those pass, also try:
+
+```sh
+pnpm run typecheck -- --filter=@weaverse/next
+pnpm run build -- --filter=@weaverse/next
+```
+
+If a command is invalid because of repo tooling, run the equivalent and document the exact command/output.
+
+## Acceptance criteria
+
+- `@weaverse/next` exists as a workspace package and builds.
+- Tests pass for provider hooks, component loader execution, and renderer fixture.
+- No source dependency/import on `react-router` or `@shopify/remix-oxygen` in `packages/next`.
+- The API matches the Pilot usage audit direction: explicit root/page data hooks, explicit commerce context, component loaders v0 must-have.
+- Update `.weaverse/specs/2026-06-19--nextjs-adapter-contract/work-log.md` with what changed, commands run, and any limitations.
+
+## Report back
+
+When done, report:
+
+- files changed
+- public API added
+- test/build commands and results
+- unresolved tradeoffs or limitations
+- anything Hermes should independently verify

--- a/.weaverse/specs/2026-06-19--nextjs-adapter-contract/work-log.md
+++ b/.weaverse/specs/2026-06-19--nextjs-adapter-contract/work-log.md
@@ -36,3 +36,34 @@
 - Wrote [`pilot-usage-audit.md`](./pilot-usage-audit.md).
 - Updated the main README to mark component loaders and explicit root/page data hooks as v0 must-haves.
 - New recommended next action: implement the small `packages/next` shell + renderer/provider spike with fixture tests.
+
+## 2026-06-19 — Alan (packages/next v0 shell)
+
+- Created a self-contained Claude Code handoff at [`claude-goal-packages-next-v0.md`](./claude-goal-packages-next-v0.md).
+- Ran Claude Code 2.1.179 in print mode on branch `feat/next-adapter-shell`; Claude hit `Reached max turns (45)` after producing a partial diff.
+- Finished verification/fixes manually:
+  - fixed TypeScript errors in tests, loader recursion, and renderer root id handling
+  - added required `'use client'` boundaries to provider/hooks/renderer for Next App Router
+  - memoized provider context value to avoid avoidable renderer/store reinitialization
+  - removed generated `dist/` output from the working tree
+  - removed unnecessary optional `next` peer dependency to avoid pulling Next/sharp into the lockfile
+  - made React/ReactDOM peer dependencies so tests use one React instance with `@weaverse/react`
+  - corrected lockfile to add only the minimal `packages/next` importer without upgrading Vite+/tooling
+- Implemented `@weaverse/next` v0 package shell:
+  - `createWeaverseNextClient`
+  - `WeaverseNextProvider`
+  - `WeaverseNextRenderer`
+  - `runWeaverseComponentLoaders`
+  - explicit hooks: `useWeaverseRootData`, `useWeaversePageData`, `useWeaverseCommerce`, `useThemeSettings`
+  - schema/runtime hook re-exports for migration ergonomics
+- Added tests for provider hooks, outside-provider errors, component loader commerce/storefront alias, inline child loader recursion, renderer fixture output, and no `react-router` / `@shopify/remix-oxygen` imports in `packages/next/src`.
+- Verification results:
+  - `pnpm install --frozen-lockfile --ignore-scripts` ✅
+  - `pnpm --filter @weaverse/next test` ✅ — 9 tests passed
+  - `pnpm --filter @weaverse/next typecheck` ✅
+  - `pnpm --filter @weaverse/next build` ✅
+  - `pnpm run biome -- packages/next` ✅
+  - `pnpm exec turbo run typecheck --filter=@weaverse/next` ✅
+  - `pnpm exec turbo run build --filter=@weaverse/next` ✅
+  - autoreview-copilot local review ✅ — clean after fixing client-boundary/memoization findings
+- Known limitation: network I/O is intentionally injected through `fetchPage` / `fetchThemeSettings`; this slice proves contract shape and rendering/loader mechanics, not the production Weaverse API fetcher.

--- a/packages/next/.gitignore
+++ b/packages/next/.gitignore
@@ -1,0 +1,5 @@
+*.log
+.DS_Store
+node_modules
+.cache
+dist

--- a/packages/next/.gitkeep
+++ b/packages/next/.gitkeep
@@ -1,1 +1,0 @@
-Coming Soon 2024.

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -174,7 +174,28 @@ describe('hooks outside provider', () => {
   })
 })
 
-// ─── 3. Component loader execution ───────────────────────────────────
+// ─── 3. Client fetchers are request-safe ──────────────────────────────
+
+describe('createWeaverseNextClient', () => {
+  it('should_return_loaded_page_without_mutating_shared_client_data', async () => {
+    // Arrange
+    let pageData = makePageData()
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [heroComponent],
+      fetchPage: async () => pageData,
+    })
+
+    // Act
+    let result = await client.loadPage({ type: 'INDEX' })
+
+    // Assert
+    expect(result).toBe(pageData)
+    expect(client.data).toBeNull()
+  })
+})
+
+// ─── 4. Component loader execution ───────────────────────────────────
 
 describe('runWeaverseComponentLoaders', () => {
   it('should_pass_commerce_storefront_and_alias_then_attach_loaderData', async () => {

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -1,0 +1,315 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { forwardRef, type ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createSchema,
+  createWeaverseNextClient,
+  runWeaverseComponentLoaders,
+  useThemeSettings,
+  useWeaverseCommerce,
+  useWeaversePageData,
+  useWeaverseRootData,
+  WeaverseNextProvider,
+  WeaverseNextRenderer,
+} from '../src/index'
+import type {
+  WeaverseNextComponentLoaderArgs,
+  WeaverseNextComponentProps,
+  WeaverseNextLoaderData,
+} from '../src/types'
+
+const OUTSIDE_PROVIDER_ERROR = /must be used inside a <WeaverseNextProvider>/
+
+// ─── Fixtures ────────────────────────────────────────────────────────
+
+const heroSchema = createSchema({
+  type: 'hero',
+  title: 'Hero',
+  settings: [
+    {
+      group: 'Content',
+      inputs: [
+        {
+          type: 'text',
+          name: 'heading',
+          label: 'Heading',
+          defaultValue: 'Default Heading',
+        },
+      ],
+    },
+  ],
+})
+
+const Hero = forwardRef<HTMLElement, WeaverseNextComponentProps>(
+  (props, ref) => (
+    <section ref={ref}>
+      <h1>{props.heading as string}</h1>
+      <p>{props.text as string}</p>
+      {props.children as ReactNode}
+    </section>
+  )
+)
+Hero.displayName = 'Hero'
+
+const heroComponent = { default: Hero, schema: heroSchema }
+
+function makeClient(overrides = {}) {
+  return createWeaverseNextClient({
+    projectId: 'proj-test',
+    components: [heroComponent],
+    ...overrides,
+  })
+}
+
+function makePageData(): WeaverseNextLoaderData {
+  return {
+    page: {
+      id: 'page-1',
+      rootId: 'item-root',
+      items: [{ id: 'item-root', type: 'hero', data: { text: 'Hello World' } }],
+    },
+  }
+}
+
+// ─── 1. Provider hooks return explicit data ──────────────────────────
+
+describe('WeaverseNextProvider hooks', () => {
+  it('should_expose_rootData_pageData_and_commerce_when_inside_provider', () => {
+    // Arrange
+    let rootData = { shop: { name: 'Test Shop' } }
+    let pageData = { product: { title: 'Amazing Product' } }
+    let storefront = { query: vi.fn(), i18n: { country: 'US', language: 'EN' } }
+    let commerce = { storefront }
+
+    function Probe() {
+      let root = useWeaverseRootData<typeof rootData>()
+      let page = useWeaversePageData<typeof pageData>()
+      let c = useWeaverseCommerce<typeof commerce>()
+      return (
+        <div>
+          {root.shop.name}|{page.product.title}|{c.storefront.i18n?.country}
+        </div>
+      )
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextProvider
+        client={makeClient()}
+        commerce={commerce}
+        pageData={pageData}
+        rootData={rootData}
+      >
+        <Probe />
+      </WeaverseNextProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Test Shop|Amazing Product|US')
+  })
+
+  it('should_expose_themeSettings_from_client_when_inside_provider', () => {
+    // Arrange
+    let client = makeClient({ themeSettings: { topbarText: 'Free shipping' } })
+
+    function Probe() {
+      let theme = useThemeSettings<{ topbarText: string }>()
+      return <span>{theme.topbarText}</span>
+    }
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextProvider client={client}>
+        <Probe />
+      </WeaverseNextProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Free shipping')
+  })
+})
+
+// ─── 2. Hooks throw outside the provider ─────────────────────────────
+
+describe('hooks outside provider', () => {
+  it('should_throw_clear_error_when_useWeaverseRootData_used_outside_provider', () => {
+    // Arrange
+    function Probe() {
+      useWeaverseRootData()
+      return null
+    }
+
+    // Act + Assert
+    expect(() => renderToStaticMarkup(<Probe />)).toThrow(
+      OUTSIDE_PROVIDER_ERROR
+    )
+  })
+
+  it('should_throw_clear_error_when_useWeaverseCommerce_used_outside_provider', () => {
+    // Arrange
+    function Probe() {
+      useWeaverseCommerce()
+      return null
+    }
+
+    // Act + Assert
+    expect(() => renderToStaticMarkup(<Probe />)).toThrow(
+      OUTSIDE_PROVIDER_ERROR
+    )
+  })
+})
+
+// ─── 3. Component loader execution ───────────────────────────────────
+
+describe('runWeaverseComponentLoaders', () => {
+  it('should_pass_commerce_storefront_and_alias_then_attach_loaderData', async () => {
+    // Arrange
+    let queryResult = { products: [{ id: 1 }] }
+    let query = vi.fn().mockResolvedValue(queryResult)
+    let storefront = { query, i18n: { country: 'US', language: 'EN' } }
+    let received: WeaverseNextComponentLoaderArgs | null = null
+
+    let loaderComponent = {
+      default: Hero,
+      schema: createSchema({ type: 'featured', title: 'Featured' }),
+      loader: async (args: WeaverseNextComponentLoaderArgs) => {
+        received = args
+        // Both the explicit commerce path and the alias must resolve.
+        await args.commerce?.storefront?.query('query Products { id }')
+        await args.weaverse.storefront?.query('query Alias { id }')
+        return queryResult
+      },
+    }
+
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [loaderComponent],
+      commerce: { storefront },
+      requestContext: { pathname: '/', isDesignMode: false },
+    })
+
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'page-1',
+        items: [{ id: 'f1', type: 'featured', data: { count: 4 } }],
+      },
+    }
+
+    // Act
+    let result = await runWeaverseComponentLoaders({ client, data })
+
+    // Assert
+    expect(received).not.toBeNull()
+    let args = received as unknown as WeaverseNextComponentLoaderArgs
+    expect(args.data).toEqual({
+      count: 4,
+    })
+    expect(query).toHaveBeenCalledTimes(2)
+    expect(result?.page.items[0].loaderData).toEqual(queryResult)
+  })
+
+  it('should_walk_inline_children_recursively', async () => {
+    // Arrange
+    let loaderCalls: string[] = []
+    let component = {
+      default: Hero,
+      schema: createSchema({ type: 'node', title: 'Node' }),
+      loader: async (args: WeaverseNextComponentLoaderArgs<{ id: string }>) => {
+        loaderCalls.push(args.data.id)
+        return null
+      },
+    }
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [component],
+    })
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'page-1',
+        items: [
+          {
+            id: 'parent',
+            type: 'node',
+            data: { id: 'parent' },
+            children: [
+              {
+                id: 'child',
+                type: 'node',
+                data: { id: 'child' },
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    // Act
+    await runWeaverseComponentLoaders({ client, data })
+
+    // Assert
+    expect(loaderCalls).toEqual(['parent', 'child'])
+  })
+})
+
+// ─── 4. Renderer renders a fixture tree ──────────────────────────────
+
+describe('WeaverseNextRenderer', () => {
+  it('should_render_registered_component_with_schema_default_and_item_props', () => {
+    // Arrange
+    let client = makeClient()
+    client.data = makePageData()
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextProvider client={client}>
+        <WeaverseNextRenderer />
+      </WeaverseNextProvider>
+    )
+
+    // Assert
+    expect(html).toContain('Default Heading') // schema default
+    expect(html).toContain('Hello World') // item data prop
+    expect(html).toContain('data-weaverse-project-id="proj-test"')
+  })
+
+  it('should_render_from_explicit_client_and_data_props', () => {
+    // Arrange
+    let client = makeClient()
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRenderer client={client} data={makePageData()} />
+    )
+
+    // Assert
+    expect(html).toContain('Hello World')
+  })
+})
+
+// ─── 5. No React Router / remix-oxygen source imports ────────────────
+
+describe('package boundaries', () => {
+  it('should_not_import_react_router_or_remix_oxygen_in_src', () => {
+    // Arrange
+    let srcDir = join(import.meta.dirname, '..', 'src')
+    let files = readdirSync(srcDir).filter((f) => /\.(ts|tsx)$/.test(f))
+
+    // Act
+    let offenders: string[] = []
+    for (let file of files) {
+      let content = readFileSync(join(srcDir, file), 'utf8')
+      if (
+        content.includes('react-router') ||
+        content.includes('@shopify/remix-oxygen')
+      ) {
+        offenders.push(file)
+      }
+    }
+
+    // Assert
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -259,7 +259,10 @@ describe('runWeaverseComponentLoaders', () => {
       count: 4,
     })
     expect(query).toHaveBeenCalledTimes(2)
+    expect(result).not.toBe(data)
+    expect(result?.page.items[0]).not.toBe(data.page.items[0])
     expect(result?.page.items[0].loaderData).toEqual(queryResult)
+    expect(data.page.items[0].loaderData).toBeUndefined()
   })
 
   it('should_walk_inline_children_recursively', async () => {

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { forwardRef, type ReactNode } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import {
@@ -21,6 +21,7 @@ import type {
 } from '../src/types'
 
 const OUTSIDE_PROVIDER_ERROR = /must be used inside a <WeaverseNextProvider>/
+const SRC_FILE_REGEX = /\.(ts|tsx)$/
 
 // ─── Fixtures ────────────────────────────────────────────────────────
 
@@ -42,14 +43,15 @@ const heroSchema = createSchema({
   ],
 })
 
-const Hero = forwardRef<HTMLElement, WeaverseNextComponentProps>(
-  (props, ref) => (
-    <section ref={ref}>
-      <h1>{props.heading as string}</h1>
-      <p>{props.text as string}</p>
-      {props.children as ReactNode}
-    </section>
-  )
+const Hero = ({
+  ref,
+  ...props
+}: WeaverseNextComponentProps & { ref?: RefObject<HTMLElement | null> }) => (
+  <section ref={ref}>
+    <h1>{props.heading as string}</h1>
+    <p>{props.text as string}</p>
+    {props.children as ReactNode}
+  </section>
 )
 Hero.displayName = 'Hero'
 
@@ -226,11 +228,11 @@ describe('runWeaverseComponentLoaders', () => {
     let loaderComponent = {
       default: Hero,
       schema: createSchema({ type: 'featured', title: 'Featured' }),
-      loader: async (args: WeaverseNextComponentLoaderArgs) => {
-        received = args
+      loader: async (loaderArgs: WeaverseNextComponentLoaderArgs) => {
+        received = loaderArgs
         // Both the explicit commerce path and the alias must resolve.
-        await args.commerce?.storefront?.query('query Products { id }')
-        await args.weaverse.storefront?.query('query Alias { id }')
+        await loaderArgs.commerce?.storefront?.query('query Products { id }')
+        await loaderArgs.weaverse.storefront?.query('query Alias { id }')
         return queryResult
       },
     }
@@ -254,8 +256,8 @@ describe('runWeaverseComponentLoaders', () => {
 
     // Assert
     expect(received).not.toBeNull()
-    let args = received as unknown as WeaverseNextComponentLoaderArgs
-    expect(args.data).toEqual({
+    let capturedArgs = received as unknown as WeaverseNextComponentLoaderArgs
+    expect(capturedArgs.data).toEqual({
       count: 4,
     })
     expect(query).toHaveBeenCalledTimes(2)
@@ -271,9 +273,9 @@ describe('runWeaverseComponentLoaders', () => {
     let component = {
       default: Hero,
       schema: createSchema({ type: 'node', title: 'Node' }),
-      loader: async (args: WeaverseNextComponentLoaderArgs<{ id: string }>) => {
+      loader: (args: WeaverseNextComponentLoaderArgs<{ id: string }>) => {
         loaderCalls.push(args.data.id)
-        return null
+        return Promise.resolve(null)
       },
     }
     let client = createWeaverseNextClient({
@@ -350,7 +352,7 @@ describe('package boundaries', () => {
   it('should_not_import_react_router_or_remix_oxygen_in_src', () => {
     // Arrange
     let srcDir = join(import.meta.dirname, '..', 'src')
-    let files = readdirSync(srcDir).filter((f) => /\.(ts|tsx)$/.test(f))
+    let files = readdirSync(srcDir).filter((f) => SRC_FILE_REGEX.test(f))
 
     // Act
     let offenders: string[] = []

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -267,6 +267,105 @@ describe('runWeaverseComponentLoaders', () => {
     expect(data.page.items[0].loaderData).toBeUndefined()
   })
 
+  it('should_merge_schema_defaults_before_running_component_loader', async () => {
+    // Arrange
+    let receivedData: unknown
+    let component = {
+      default: Hero,
+      schema: createSchema({
+        type: 'featured-defaults',
+        title: 'Featured Defaults',
+        settings: [
+          {
+            group: 'Content',
+            inputs: [
+              {
+                type: 'range',
+                name: 'count',
+                label: 'Count',
+                defaultValue: 8,
+              },
+              {
+                type: 'text',
+                name: 'heading',
+                label: 'Heading',
+                defaultValue: 'Featured products',
+              },
+            ],
+          },
+        ],
+      }),
+      loader: (args: WeaverseNextComponentLoaderArgs) => {
+        receivedData = args.data
+        return Promise.resolve({ ok: true })
+      },
+    }
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [component],
+    })
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'page-1',
+        items: [
+          {
+            id: 'featured-1',
+            type: 'featured-defaults',
+            data: { heading: 'Manual heading' },
+          },
+        ],
+      },
+    }
+
+    // Act
+    await runWeaverseComponentLoaders({ client, data })
+
+    // Assert
+    expect(receivedData).toEqual({ count: 8, heading: 'Manual heading' })
+  })
+
+  it('should_keep_rendering_other_items_when_one_component_loader_fails', async () => {
+    // Arrange
+    let warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    let failingComponent = {
+      default: Hero,
+      schema: createSchema({ type: 'failing', title: 'Failing' }),
+      loader: () => Promise.reject(new Error('storefront failed')),
+    }
+    let workingComponent = {
+      default: Hero,
+      schema: createSchema({ type: 'working', title: 'Working' }),
+      loader: async () => ({ ok: true }),
+    }
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [failingComponent, workingComponent],
+    })
+    let data: WeaverseNextLoaderData = {
+      page: {
+        id: 'page-1',
+        items: [
+          { id: 'bad', type: 'failing', data: {} },
+          { id: 'good', type: 'working', data: {} },
+        ],
+      },
+    }
+
+    // Act
+    let result = await runWeaverseComponentLoaders({ client, data })
+
+    // Assert
+    expect(result?.page.items[0].loaderData).toBeUndefined()
+    expect(result?.page.items[1].loaderData).toEqual({ ok: true })
+    expect(warn).toHaveBeenCalledWith(
+      '❌ Item loader run failed.',
+      'failing',
+      'bad',
+      expect.any(Error)
+    )
+    warn.mockRestore()
+  })
+
   it('should_walk_inline_children_recursively', async () => {
     // Arrange
     let loaderCalls: string[] = []

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -179,6 +179,46 @@ describe('hooks outside provider', () => {
 // ─── 3. Client fetchers are request-safe ──────────────────────────────
 
 describe('createWeaverseNextClient', () => {
+  it('should_seed_theme_schema_defaults_under_merchant_overrides', () => {
+    // Arrange — theme schema declares two settings with defaults; the merchant
+    // only overrides one of them.
+    let themeSchema = createSchema({
+      type: 'theme',
+      title: 'Theme',
+      settings: [
+        {
+          group: 'Layout',
+          inputs: [
+            {
+              type: 'range',
+              name: 'pageWidth',
+              label: 'Page width',
+              defaultValue: 1200,
+            },
+            {
+              type: 'text',
+              name: 'topbarText',
+              label: 'Topbar text',
+              defaultValue: 'Default topbar',
+            },
+          ],
+        },
+      ],
+    })
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [heroComponent],
+      themeSchema,
+      themeSettings: { topbarText: 'Merchant topbar' },
+    })
+
+    // Assert — schema default fills the missing key; override wins where set.
+    expect(client.themeSettings).toEqual({
+      pageWidth: 1200,
+      topbarText: 'Merchant topbar',
+    })
+  })
+
   it('should_return_loaded_page_without_mutating_shared_client_data', async () => {
     // Arrange
     let pageData = makePageData()
@@ -265,6 +305,45 @@ describe('runWeaverseComponentLoaders', () => {
     expect(result?.page.items[0]).not.toBe(data.page.items[0])
     expect(result?.page.items[0].loaderData).toEqual(queryResult)
     expect(data.page.items[0].loaderData).toBeUndefined()
+  })
+
+  it('should_point_weaverse_storefront_alias_at_per_call_commerce', async () => {
+    // Arrange — client built with a construction-time storefront, but the
+    // loader run receives a different request-scoped commerce.
+    let clientQuery = vi.fn().mockResolvedValue({ from: 'client' })
+    let clientStorefront = { query: clientQuery, i18n: { country: 'US' } }
+    let requestQuery = vi.fn().mockResolvedValue({ from: 'request' })
+    let requestStorefront = { query: requestQuery, i18n: { country: 'JP' } }
+    let aliasStorefront: unknown
+    let component = {
+      default: Hero,
+      schema: createSchema({ type: 'aliased', title: 'Aliased' }),
+      loader: async (args: WeaverseNextComponentLoaderArgs) => {
+        aliasStorefront = args.weaverse.storefront
+        await args.weaverse.storefront?.query('query Alias { id }')
+        return { ok: true }
+      },
+    }
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [component],
+      commerce: { storefront: clientStorefront },
+    })
+    let data: WeaverseNextLoaderData = {
+      page: { id: 'page-1', items: [{ id: 'a1', type: 'aliased', data: {} }] },
+    }
+
+    // Act — pass request-scoped commerce that differs from client.commerce.
+    await runWeaverseComponentLoaders({
+      client,
+      data,
+      commerce: { storefront: requestStorefront },
+    })
+
+    // Assert — the alias resolves to the per-call storefront, not the stale one.
+    expect(aliasStorefront).toBe(requestStorefront)
+    expect(requestQuery).toHaveBeenCalledTimes(1)
+    expect(clientQuery).not.toHaveBeenCalled()
   })
 
   it('should_merge_schema_defaults_before_running_component_loader', async () => {

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -346,6 +346,94 @@ describe('WeaverseNextRenderer', () => {
   })
 })
 
+// ─── 4b. Default `main` root handling ────────────────────────────────
+
+// Flat page model: a single root `main` item whose `children` are `{ id }`
+// refs into the top-level `items` array — the shape Weaverse actually serves.
+function makeFlatPageData(): WeaverseNextLoaderData {
+  return {
+    page: {
+      id: 'page-flat',
+      items: [
+        {
+          id: 'item-main',
+          type: 'main',
+          children: [{ id: 'hero-1' }, { id: 'hero-2' }],
+        },
+        { id: 'hero-1', type: 'hero', data: { text: 'First section' } },
+        { id: 'hero-2', type: 'hero', data: { text: 'Second section' } },
+      ],
+    },
+  }
+}
+
+describe('default main root handling', () => {
+  it('should_render_child_sections_when_consumer_does_not_register_main', () => {
+    // Arrange — client registers only `hero`, never a `main` component.
+    let client = makeClient()
+    client.data = makeFlatPageData()
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextProvider client={client}>
+        <WeaverseNextRenderer />
+      </WeaverseNextProvider>
+    )
+
+    // Assert — both children resolved through the default `main` root.
+    expect(html).toContain('First section')
+    expect(html).toContain('Second section')
+    expect(html).toContain('Default Heading') // hero schema default
+  })
+
+  it('should_forward_weaverse_dom_attributes_onto_the_default_main_element', () => {
+    // Arrange
+    let client = makeClient()
+    client.data = makeFlatPageData()
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRenderer client={client} data={client.data} />
+    )
+
+    // Assert — default `main` spreads the renderer-injected DOM attributes.
+    expect(html).toContain('data-wv-id="item-main"')
+    expect(html).toContain('data-wv-type="main"')
+  })
+
+  it('should_prefer_user_registered_main_over_the_default_main', () => {
+    // Arrange — this runs after the default `main` has already been registered.
+    let CustomMain = (props: WeaverseNextComponentProps) => {
+      let { children, ...rest } = props
+      return (
+        <main {...rest} data-custom-main="yes">
+          {children as ReactNode}
+        </main>
+      )
+    }
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [
+        {
+          default: CustomMain,
+          schema: createSchema({ type: 'main', title: 'Main' }),
+        },
+        heroComponent,
+      ],
+    })
+    client.data = makeFlatPageData()
+
+    // Act
+    let html = renderToStaticMarkup(
+      <WeaverseNextRenderer client={client} data={client.data} />
+    )
+
+    // Assert
+    expect(html).toContain('data-custom-main="yes"')
+    expect(html).toContain('First section')
+  })
+})
+
 // ─── 5. No React Router / remix-oxygen source imports ────────────────
 
 describe('package boundaries', () => {

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -159,6 +159,19 @@ describe('hooks outside provider', () => {
       OUTSIDE_PROVIDER_ERROR
     )
   })
+
+  it('should_throw_clear_error_when_useWeaversePageData_used_outside_provider', () => {
+    // Arrange
+    function Probe() {
+      useWeaversePageData()
+      return null
+    }
+
+    // Act + Assert
+    expect(() => renderToStaticMarkup(<Probe />)).toThrow(
+      OUTSIDE_PROVIDER_ERROR
+    )
+  })
 })
 
 // ─── 3. Component loader execution ───────────────────────────────────

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -193,6 +193,24 @@ describe('createWeaverseNextClient', () => {
     expect(result).toBe(pageData)
     expect(client.data).toBeNull()
   })
+
+  it('should_return_loaded_theme_settings_without_mutating_shared_client_theme_settings', async () => {
+    // Arrange
+    let themeSettings = { topbarText: 'Request scoped' }
+    let client = createWeaverseNextClient({
+      projectId: 'proj-test',
+      components: [heroComponent],
+      themeSettings: { topbarText: 'Initial' },
+      fetchThemeSettings: async () => themeSettings,
+    })
+
+    // Act
+    let result = await client.loadThemeSettings()
+
+    // Assert
+    expect(result).toBe(themeSettings)
+    expect(client.themeSettings).toEqual({ topbarText: 'Initial' })
+  })
 })
 
 // ─── 4. Component loader execution ───────────────────────────────────

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@weaverse/next",
+  "author": "Weaverse Team",
+  "description": "Next.js App Router integration for building Weaverse-powered storefronts",
+  "version": "5.16.3",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "module": "dist/index.mjs",
+  "publishConfig": {
+    "access": "public",
+    "@weaverse:registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "url": "git+https://github.com/Weaverse/weaverse.git",
+    "directory": "packages/next"
+  },
+  "files": [
+    "dist/*"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "tsup --watch",
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "tsup": {
+    "entry": [
+      "src/index.ts"
+    ],
+    "format": [
+      "esm",
+      "cjs"
+    ],
+    "dts": true,
+    "sourcemap": true,
+    "clean": true,
+    "outDir": "dist",
+    "treeshake": true
+  },
+  "dependencies": {
+    "@weaverse/react": "5.16.3",
+    "@weaverse/schema": "0.10.0"
+  },
+  "peerDependencies": {
+    "react": ">=19",
+    "react-dom": ">=19"
+  }
+}

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -25,7 +25,7 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "clean": "rimraf dist",
-    "test": "vitest run",
+    "test": "pnpm --dir ../.. exec vitest run --config packages/next/vitest.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "tsup": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -2,7 +2,7 @@
   "name": "@weaverse/next",
   "author": "Weaverse Team",
   "description": "Next.js App Router integration for building Weaverse-powered storefronts",
-  "version": "5.16.3",
+  "version": "0.1.0-alpha.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -25,7 +25,7 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "clean": "rimraf dist",
-    "test": "pnpm --dir ../.. exec vitest run --config packages/next/vitest.config.ts",
+    "test": "vp test --run --config vitest.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "tsup": {

--- a/packages/next/src/client.ts
+++ b/packages/next/src/client.ts
@@ -1,3 +1,4 @@
+import { registerWeaverseNextComponents } from './registry'
 import type {
   WeaverseNextClient,
   WeaverseNextClientConfig,
@@ -34,6 +35,7 @@ class NextClient implements WeaverseNextClient {
   constructor(config: WeaverseNextClientConfig) {
     this.projectId = config.projectId
     this.components = config.components ?? []
+    registerWeaverseNextComponents(this.components)
     this.themeSchema = config.themeSchema
     this.themeSettings = config.themeSettings ?? {}
     this.requestContext = config.requestContext

--- a/packages/next/src/client.ts
+++ b/packages/next/src/client.ts
@@ -29,12 +29,12 @@ class NextClient implements WeaverseNextClient {
   data: WeaverseNextLoaderData | null = null
   dataContext: Record<string, unknown> = {}
 
-  private _fetchPage?: WeaverseNextClientConfig['fetchPage']
-  private _fetchThemeSettings?: WeaverseNextClientConfig['fetchThemeSettings']
+  private readonly _fetchPage?: WeaverseNextClientConfig['fetchPage']
+  private readonly _fetchThemeSettings?: WeaverseNextClientConfig['fetchThemeSettings']
 
   constructor(config: WeaverseNextClientConfig) {
     this.projectId = config.projectId
-    this.components = config.components ?? []
+    this.components = config.components
     registerWeaverseNextComponents(this.components)
     this.themeSchema = config.themeSchema
     this.themeSettings = config.themeSettings ?? {}
@@ -49,7 +49,7 @@ class NextClient implements WeaverseNextClient {
     return this.commerce?.storefront
   }
 
-  loadPage = async (
+  loadPage = (
     input: WeaverseNextLoadPageInput = {}
   ): Promise<WeaverseNextLoaderData | null> => {
     if (!this._fetchPage) {
@@ -60,7 +60,7 @@ class NextClient implements WeaverseNextClient {
     return this._fetchPage(input)
   }
 
-  loadThemeSettings = async (
+  loadThemeSettings = (
     context?: WeaverseNextRequestContext
   ): Promise<unknown> => {
     if (!this._fetchThemeSettings) {

--- a/packages/next/src/client.ts
+++ b/packages/next/src/client.ts
@@ -1,3 +1,4 @@
+import type { SchemaType } from '@weaverse/schema'
 import { registerWeaverseNextComponents } from './registry'
 import type {
   WeaverseNextClient,
@@ -9,6 +10,7 @@ import type {
   WeaverseNextRequestContext,
   WeaverseNextStorefront,
 } from './types'
+import { generateDataFromSchema } from './utils'
 
 /**
  * Request-safe Weaverse client for Next.js. Holds the component registry, theme
@@ -37,7 +39,14 @@ class NextClient implements WeaverseNextClient {
     this.components = config.components
     registerWeaverseNextComponents(this.components)
     this.themeSchema = config.themeSchema
-    this.themeSettings = config.themeSettings ?? {}
+    // Seed `themeSchema` defaults before merchant-provided overrides, mirroring
+    // Hydrogen's `loadThemeSettings` (schema defaults under remote `theme`).
+    // Without this, `useThemeSettings()` would miss any setting the merchant
+    // never explicitly overrode.
+    this.themeSettings = {
+      ...generateDataFromSchema(config.themeSchema as SchemaType | undefined),
+      ...config.themeSettings,
+    }
     this.requestContext = config.requestContext
     this.commerce = config.commerce
     this._fetchPage = config.fetchPage

--- a/packages/next/src/client.ts
+++ b/packages/next/src/client.ts
@@ -68,13 +68,7 @@ class NextClient implements WeaverseNextClient {
         '[WeaverseNextClient] loadThemeSettings requires a `fetchThemeSettings` function in client config.'
       )
     }
-    let settings = await this._fetchThemeSettings(
-      context ?? this.requestContext
-    )
-    if (settings && typeof settings === 'object') {
-      this.themeSettings = settings as Record<string, unknown>
-    }
-    return settings
+    return this._fetchThemeSettings(context ?? this.requestContext)
   }
 }
 

--- a/packages/next/src/client.ts
+++ b/packages/next/src/client.ts
@@ -1,0 +1,98 @@
+import type {
+  WeaverseNextClient,
+  WeaverseNextClientConfig,
+  WeaverseNextCommerceContext,
+  WeaverseNextComponent,
+  WeaverseNextLoaderData,
+  WeaverseNextLoadPageInput,
+  WeaverseNextRequestContext,
+  WeaverseNextStorefront,
+} from './types'
+
+/**
+ * Request-safe Weaverse client for Next.js. Holds the component registry, theme
+ * data, request/commerce context, and the currently loaded page payload.
+ *
+ * Unlike Hydrogen's `WeaverseClient`, it never receives a React Router
+ * `Request`/`LoaderFunctionArgs`. Network I/O is delegated to `fetchPage` /
+ * `fetchThemeSettings` injected through config, keeping v0 testable without
+ * real Weaverse API calls.
+ */
+class NextClient implements WeaverseNextClient {
+  projectId: string
+  components: WeaverseNextComponent[]
+  themeSchema?: unknown
+  themeSettings: Record<string, unknown>
+  requestContext?: WeaverseNextRequestContext
+  commerce?: WeaverseNextCommerceContext
+  data: WeaverseNextLoaderData | null = null
+  dataContext: Record<string, unknown> = {}
+
+  private _fetchPage?: WeaverseNextClientConfig['fetchPage']
+  private _fetchThemeSettings?: WeaverseNextClientConfig['fetchThemeSettings']
+
+  constructor(config: WeaverseNextClientConfig) {
+    this.projectId = config.projectId
+    this.components = config.components ?? []
+    this.themeSchema = config.themeSchema
+    this.themeSettings = config.themeSettings ?? {}
+    this.requestContext = config.requestContext
+    this.commerce = config.commerce
+    this._fetchPage = config.fetchPage
+    this._fetchThemeSettings = config.fetchThemeSettings
+  }
+
+  /** Compatibility alias so loaders can call `weaverse.storefront.query(...)`. */
+  get storefront(): WeaverseNextStorefront | undefined {
+    return this.commerce?.storefront
+  }
+
+  loadPage = async (
+    input: WeaverseNextLoadPageInput = {}
+  ): Promise<WeaverseNextLoaderData | null> => {
+    if (!this._fetchPage) {
+      throw new Error(
+        '[WeaverseNextClient] loadPage requires a `fetchPage` function in client config.'
+      )
+    }
+    let result = await this._fetchPage(input)
+    this.data = result
+    return result
+  }
+
+  loadThemeSettings = async (
+    context?: WeaverseNextRequestContext
+  ): Promise<unknown> => {
+    if (!this._fetchThemeSettings) {
+      throw new Error(
+        '[WeaverseNextClient] loadThemeSettings requires a `fetchThemeSettings` function in client config.'
+      )
+    }
+    let settings = await this._fetchThemeSettings(
+      context ?? this.requestContext
+    )
+    if (settings && typeof settings === 'object') {
+      this.themeSettings = settings as Record<string, unknown>
+    }
+    return settings
+  }
+}
+
+/**
+ * Create a {@link WeaverseNextClient} from explicit config.
+ *
+ * @example
+ * ```ts
+ * let client = createWeaverseNextClient({
+ *   projectId: process.env.WEAVERSE_PROJECT_ID!,
+ *   components,
+ *   commerce: { storefront },
+ *   fetchPage: async ({ type, handle }) => fetchWeaversePage({ type, handle }),
+ * })
+ * ```
+ */
+export function createWeaverseNextClient(
+  config: WeaverseNextClientConfig
+): WeaverseNextClient {
+  return new NextClient(config)
+}

--- a/packages/next/src/client.ts
+++ b/packages/next/src/client.ts
@@ -57,9 +57,7 @@ class NextClient implements WeaverseNextClient {
         '[WeaverseNextClient] loadPage requires a `fetchPage` function in client config.'
       )
     }
-    let result = await this._fetchPage(input)
-    this.data = result
-    return result
+    return this._fetchPage(input)
   }
 
   loadThemeSettings = async (

--- a/packages/next/src/hooks.ts
+++ b/packages/next/src/hooks.ts
@@ -1,0 +1,44 @@
+'use client'
+
+import { useContext } from 'react'
+import { WeaverseNextContext } from './provider'
+import type { WeaverseNextCommerceContext } from './types'
+
+const OUTSIDE_PROVIDER_ERROR = 'must be used inside a <WeaverseNextProvider>.'
+
+function useWeaverseNextContext(hookName: string) {
+  let context = useContext(WeaverseNextContext)
+  if (!context) {
+    throw new Error(`[@weaverse/next] ${hookName} ${OUTSIDE_PROVIDER_ERROR}`)
+  }
+  return context
+}
+
+/**
+ * Read explicit root/global data passed to the provider. Next-native
+ * replacement for `useRouteLoaderData('root')`.
+ */
+export function useWeaverseRootData<T = unknown>(): T {
+  return useWeaverseNextContext('useWeaverseRootData').rootData as T
+}
+
+/**
+ * Read explicit page/route commerce data passed to the provider. Next-native
+ * replacement for section-level `useLoaderData()`.
+ */
+export function useWeaversePageData<T = unknown>(): T {
+  return useWeaverseNextContext('useWeaversePageData').pageData as T
+}
+
+/** Read the app-provided commerce context (storefront/cart/customer). */
+export function useWeaverseCommerce<T = WeaverseNextCommerceContext>(): T {
+  return useWeaverseNextContext('useWeaverseCommerce').commerce as T
+}
+
+/**
+ * Read Weaverse theme settings. Next version backed by provider root/theme
+ * data (`client.themeSettings`), not the Hydrogen theme-settings store.
+ */
+export function useThemeSettings<T = Record<string, unknown>>(): T {
+  return useWeaverseNextContext('useThemeSettings').themeSettings as T
+}

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,0 +1,53 @@
+// Re-export schema authoring + runtime hooks for migration ergonomics.
+
+// Runtime hooks from @weaverse/react (item store + editor instance).
+export {
+  isBrowser,
+  isIframe,
+  useChildInstances,
+  useItemInstance,
+  useParentInstance,
+  useWeaverse,
+} from '@weaverse/react'
+export type {
+  InspectorGroup,
+  PageType,
+  SchemaType,
+} from '@weaverse/schema'
+export { createSchema } from '@weaverse/schema'
+export { createWeaverseNextClient } from './client'
+export {
+  useThemeSettings,
+  useWeaverseCommerce,
+  useWeaversePageData,
+  useWeaverseRootData,
+} from './hooks'
+export {
+  type RunComponentLoadersArgs,
+  runWeaverseComponentLoaders,
+} from './loader'
+export {
+  WeaverseNextProvider,
+  type WeaverseNextProviderProps,
+} from './provider'
+export {
+  WeaverseNextRenderer,
+  type WeaverseNextRendererProps,
+} from './renderer'
+export type {
+  WeaverseCollection,
+  WeaverseNextClient,
+  WeaverseNextClientConfig,
+  WeaverseNextCommerceContext,
+  WeaverseNextComponent,
+  WeaverseNextComponentData,
+  WeaverseNextComponentLoaderArgs,
+  WeaverseNextComponentProps,
+  WeaverseNextI18n,
+  WeaverseNextLoaderData,
+  WeaverseNextLoadPageInput,
+  WeaverseNextPageData,
+  WeaverseNextRequestContext,
+  WeaverseNextStorefront,
+  WeaverseProduct,
+} from './types'

--- a/packages/next/src/item.ts
+++ b/packages/next/src/item.ts
@@ -1,0 +1,26 @@
+import type { ElementData } from '@weaverse/react'
+import { Weaverse, WeaverseItemStore } from '@weaverse/react'
+import type { WeaverseNextComponentData } from './types'
+import { generateDataFromSchema } from './utils'
+
+/**
+ * Item store that flattens the serialized item's nested `data` field onto the
+ * store and seeds schema defaults — same shape Hydrogen produces, so the
+ * shared `@weaverse/react` renderer can spread props at the top level.
+ */
+export class WeaverseNextItem extends WeaverseItemStore {
+  constructor(initialData: WeaverseNextComponentData, weaverse: Weaverse) {
+    super(initialData as ElementData, weaverse)
+    let { data, ...rest } = initialData
+    let schemaData = generateDataFromSchema(this.Element?.schema)
+    Object.assign(this._store, schemaData, data, rest)
+  }
+}
+
+/**
+ * Register the Next item constructor globally. Idempotent: calling it more than
+ * once is safe. Invoked by the renderer before it builds a Weaverse instance.
+ */
+export function ensureNextItemConstructor() {
+  Weaverse.ItemConstructor = WeaverseNextItem
+}

--- a/packages/next/src/item.ts
+++ b/packages/next/src/item.ts
@@ -22,5 +22,11 @@ export class WeaverseNextItem extends WeaverseItemStore {
  * once is safe. Invoked by the renderer before it builds a Weaverse instance.
  */
 export function ensureNextItemConstructor() {
-  Weaverse.ItemConstructor = WeaverseNextItem
+  if (
+    !Weaverse.ItemConstructor ||
+    Weaverse.ItemConstructor === WeaverseItemStore ||
+    Weaverse.ItemConstructor === WeaverseNextItem
+  ) {
+    Weaverse.ItemConstructor = WeaverseNextItem
+  }
 }

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -23,6 +23,17 @@ function isItemNode(node: unknown): node is WeaverseNextComponentData {
   )
 }
 
+function cloneItem(item: WeaverseNextComponentData): WeaverseNextComponentData {
+  return {
+    ...item,
+    children: Array.isArray(item.children)
+      ? item.children.map((child) =>
+          isItemNode(child) ? cloneItem(child) : { ...child }
+        )
+      : item.children,
+  }
+}
+
 /**
  * Walk a serialized page tree and run each registered component's `loader`,
  * attaching the result to the item as `loaderData`.
@@ -32,17 +43,26 @@ function isItemNode(node: unknown): node is WeaverseNextComponentData {
  * they are inline item objects; flat `items` arrays are covered by the
  * top-level walk.
  *
- * @returns the same `data` object (mutated in place) for convenience.
+ * @returns a cloned `data` object with `loaderData` attached to cloned items.
  */
 export async function runWeaverseComponentLoaders(
   args: RunComponentLoadersArgs
 ): Promise<WeaverseNextLoaderData | null> {
   let { client, context, commerce } = args
-  let data = args.data ?? client.data
-  let items = data?.page?.items
-  if (!items?.length) {
-    return data
+  let sourceData = args.data ?? client.data
+  let sourceItems = sourceData?.page?.items
+  if (!(sourceData && sourceItems?.length)) {
+    return sourceData
   }
+
+  let data: WeaverseNextLoaderData = {
+    ...sourceData,
+    page: {
+      ...sourceData.page,
+      items: sourceItems.map(cloneItem),
+    },
+  }
+  let items = data.page.items
 
   let componentMap = new Map<string, WeaverseNextComponent>()
   for (let component of client.components) {

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -1,0 +1,89 @@
+import type {
+  WeaverseNextClient,
+  WeaverseNextCommerceContext,
+  WeaverseNextComponent,
+  WeaverseNextComponentData,
+  WeaverseNextLoaderData,
+  WeaverseNextRequestContext,
+} from './types'
+
+export interface RunComponentLoadersArgs {
+  client: WeaverseNextClient
+  commerce?: WeaverseNextCommerceContext
+  context?: WeaverseNextRequestContext
+  /** Page payload to walk; defaults to `client.data`. */
+  data?: WeaverseNextLoaderData | null
+}
+
+function isItemNode(node: unknown): node is WeaverseNextComponentData {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    typeof (node as WeaverseNextComponentData).type === 'string'
+  )
+}
+
+/**
+ * Walk a serialized page tree and run each registered component's `loader`,
+ * attaching the result to the item as `loaderData`.
+ *
+ * Loaders receive explicit `commerce.storefront` (and `weaverse.storefront` as
+ * a compatibility alias via the client). Children are walked recursively when
+ * they are inline item objects; flat `items` arrays are covered by the
+ * top-level walk.
+ *
+ * @returns the same `data` object (mutated in place) for convenience.
+ */
+export async function runWeaverseComponentLoaders(
+  args: RunComponentLoadersArgs
+): Promise<WeaverseNextLoaderData | null> {
+  let { client, context, commerce } = args
+  let data = args.data ?? client.data
+  let items = data?.page?.items
+  if (!items?.length) {
+    return data
+  }
+
+  let componentMap = new Map<string, WeaverseNextComponent>()
+  for (let component of client.components) {
+    if (component?.schema?.type) {
+      componentMap.set(component.schema.type, component)
+    }
+  }
+
+  let visited = new Set<string>()
+  let resolvedContext = context ?? client.requestContext
+  let resolvedCommerce = commerce ?? client.commerce
+
+  async function walk(nodes: WeaverseNextComponentData[]) {
+    for (let item of nodes) {
+      if (!item || visited.has(item.id)) {
+        continue
+      }
+      visited.add(item.id)
+
+      let component = componentMap.get(item.type)
+      if (component?.loader) {
+        item.loaderData = await component.loader({
+          data: item.data ?? {},
+          weaverse: client,
+          context: resolvedContext,
+          commerce: resolvedCommerce,
+        })
+      }
+
+      let children = item.children
+      if (Array.isArray(children)) {
+        let inlineChildren = children.filter(
+          isItemNode
+        ) as WeaverseNextComponentData[]
+        if (inlineChildren.length) {
+          await walk(inlineChildren)
+        }
+      }
+    }
+  }
+
+  await walk(items)
+  return data
+}

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -78,6 +78,21 @@ export async function runWeaverseComponentLoaders(
   let resolvedContext = context ?? client.requestContext
   let resolvedCommerce = commerce ?? client.commerce
 
+  // Per-call `weaverse` alias. When a request-scoped `commerce` is passed, the
+  // `weaverse.storefront` compatibility alias must resolve to *that* storefront,
+  // not the client's construction-time commerce. Pilot-style loaders call
+  // `weaverse.storefront.query(...)`, so a stale alias would query the wrong
+  // (or an undefined) storefront. When no override is given we reuse the client
+  // as-is to preserve its prototype getters.
+  let resolvedWeaverse: WeaverseNextClient =
+    resolvedCommerce === client.commerce
+      ? client
+      : {
+          ...client,
+          commerce: resolvedCommerce,
+          storefront: resolvedCommerce?.storefront,
+        }
+
   async function walk(nodes: WeaverseNextComponentData[]) {
     for (let item of nodes) {
       if (!item || visited.has(item.id)) {
@@ -90,7 +105,7 @@ export async function runWeaverseComponentLoaders(
         try {
           item.loaderData = await component.loader({
             data: { ...generateDataFromSchema(component.schema), ...item.data },
-            weaverse: client,
+            weaverse: resolvedWeaverse,
             context: resolvedContext,
             commerce: resolvedCommerce,
           })

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -50,16 +50,15 @@ export async function runWeaverseComponentLoaders(
 ): Promise<WeaverseNextLoaderData | null> {
   let { client, context, commerce } = args
   let sourceData = args.data ?? client.data
-  let sourceItems = sourceData?.page?.items
-  if (!(sourceData && sourceItems?.length)) {
-    return sourceData
+  if (!(sourceData && sourceData.page.items.length)) {
+    return sourceData ?? null
   }
 
   let data: WeaverseNextLoaderData = {
     ...sourceData,
     page: {
       ...sourceData.page,
-      items: sourceItems.map(cloneItem),
+      items: sourceData.page.items.map(cloneItem),
     },
   }
   let items = data.page.items

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -6,6 +6,7 @@ import type {
   WeaverseNextLoaderData,
   WeaverseNextRequestContext,
 } from './types'
+import { generateDataFromSchema } from './utils'
 
 export interface RunComponentLoadersArgs {
   client: WeaverseNextClient
@@ -50,8 +51,11 @@ export async function runWeaverseComponentLoaders(
 ): Promise<WeaverseNextLoaderData | null> {
   let { client, context, commerce } = args
   let sourceData = args.data ?? client.data
-  if (!(sourceData && sourceData.page.items.length)) {
-    return sourceData ?? null
+  if (!sourceData) {
+    return null
+  }
+  if (!sourceData.page.items.length) {
+    return sourceData
   }
 
   let data: WeaverseNextLoaderData = {
@@ -83,12 +87,16 @@ export async function runWeaverseComponentLoaders(
 
       let component = componentMap.get(item.type)
       if (component?.loader) {
-        item.loaderData = await component.loader({
-          data: item.data ?? {},
-          weaverse: client,
-          context: resolvedContext,
-          commerce: resolvedCommerce,
-        })
+        try {
+          item.loaderData = await component.loader({
+            data: { ...generateDataFromSchema(component.schema), ...item.data },
+            weaverse: client,
+            context: resolvedContext,
+            commerce: resolvedCommerce,
+          })
+        } catch (error) {
+          console.warn('❌ Item loader run failed.', item.type, item.id, error)
+        }
       }
 
       let children = item.children

--- a/packages/next/src/main.tsx
+++ b/packages/next/src/main.tsx
@@ -1,0 +1,45 @@
+import { createSchema, type SchemaType } from '@weaverse/schema'
+import type { HTMLAttributes, RefObject } from 'react'
+import type { WeaverseNextComponent, WeaverseNextComponentProps } from './types'
+
+/**
+ * Default `main` root component.
+ *
+ * A Weaverse page tree is a flat `items` array with a single root item of type
+ * `main` whose `children` are the page's top-level sections. Hydrogen ships its
+ * own `main`; the Next adapter provides this minimal, framework-neutral
+ * equivalent so consumers don't have to register one just to render a basic
+ * page tree (omitting it would leave child sections unrendered).
+ *
+ * It renders `children` and forwards the Weaverse DOM attributes the shared
+ * renderer injects (`data-wv-id`, `data-wv-type`, `ref`, `className`, ...rest)
+ * onto the root element. `loaderData` is adapter-internal and stripped so it
+ * never lands on the DOM node.
+ */
+function Main(
+  props: WeaverseNextComponentProps & {
+    ref?: RefObject<HTMLDivElement | null>
+  }
+) {
+  let { children, loaderData, ...rest } = props
+  // `rest` carries the Weaverse-injected DOM attributes (data-wv-*, ref,
+  // className). They are all valid div attributes, so the cast is safe.
+  return <div {...(rest as HTMLAttributes<HTMLDivElement>)}>{children}</div>
+}
+Main.displayName = 'main'
+
+/** Schema for the default {@link Main} root component. Type is exactly `main`. */
+export const mainSchema: SchemaType = createSchema({
+  type: 'main',
+  title: 'Main',
+})
+
+/**
+ * Default `main` component module, registered ahead of user components by
+ * {@link registerWeaverseNextComponents}. Kept package-internal — consumers
+ * override it simply by registering their own component with `type: 'main'`.
+ */
+export const defaultMainComponent: WeaverseNextComponent = {
+  default: Main,
+  schema: mainSchema,
+}

--- a/packages/next/src/provider.tsx
+++ b/packages/next/src/provider.tsx
@@ -41,8 +41,14 @@ export interface WeaverseNextProviderProps {
  * sections. Next-native replacement for `withWeaverse` + route loader data —
  * no React Router route matches are emulated.
  *
+ * In App Router, create/pass `client` only from a client component wrapper. A
+ * `WeaverseNextClient` contains functions and component references, so it is
+ * not serializable across a Server Component → Client Component boundary.
+ *
  * @example
  * ```tsx
+ * 'use client'
+ *
  * <WeaverseNextProvider client={client} rootData={rootData} pageData={pageData} commerce={commerce}>
  *   <WeaverseNextRenderer />
  * </WeaverseNextProvider>

--- a/packages/next/src/provider.tsx
+++ b/packages/next/src/provider.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { createContext, type ReactNode, useMemo } from 'react'
+import type { WeaverseNextClient, WeaverseNextCommerceContext } from './types'
+
+/**
+ * Value carried by {@link WeaverseNextContext}. Holds the explicit data
+ * boundaries that replace React Router's `useLoaderData` /
+ * `useRouteLoaderData` inside sections.
+ */
+export interface WeaverseNextContextValue {
+  client?: WeaverseNextClient
+  commerce?: WeaverseNextCommerceContext
+  pageData?: unknown
+  rootData?: unknown
+  themeSettings: Record<string, unknown>
+}
+
+/**
+ * Null sentinel default lets hooks detect usage outside the provider and throw
+ * a clear error instead of silently returning empty data.
+ */
+export const WeaverseNextContext =
+  createContext<WeaverseNextContextValue | null>(null)
+
+export interface WeaverseNextProviderProps {
+  children: ReactNode
+  client?: WeaverseNextClient
+  /** App-provided commerce context (storefront/cart/customer). */
+  commerce?: WeaverseNextCommerceContext
+  /** Explicit page/route commerce data (replaces section-level `useLoaderData`). */
+  pageData?: unknown
+  /** Explicit root/global data (replaces `useRouteLoaderData('root')`). */
+  rootData?: unknown
+  /** Theme settings override; falls back to `client.themeSettings`. */
+  themeSettings?: Record<string, unknown>
+}
+
+/**
+ * Client boundary that supplies explicit root/page/commerce data to Weaverse
+ * sections. Next-native replacement for `withWeaverse` + route loader data —
+ * no React Router route matches are emulated.
+ *
+ * @example
+ * ```tsx
+ * <WeaverseNextProvider client={client} rootData={rootData} pageData={pageData} commerce={commerce}>
+ *   <WeaverseNextRenderer />
+ * </WeaverseNextProvider>
+ * ```
+ */
+export function WeaverseNextProvider(props: WeaverseNextProviderProps) {
+  let { children, client, rootData, pageData, commerce, themeSettings } = props
+
+  let value = useMemo<WeaverseNextContextValue>(
+    () => ({
+      client,
+      rootData,
+      pageData,
+      commerce: commerce ?? client?.commerce,
+      themeSettings: themeSettings ?? client?.themeSettings ?? {},
+    }),
+    [client, rootData, pageData, commerce, themeSettings]
+  )
+
+  return (
+    <WeaverseNextContext.Provider value={value}>
+      {children}
+    </WeaverseNextContext.Provider>
+  )
+}

--- a/packages/next/src/registry.ts
+++ b/packages/next/src/registry.ts
@@ -21,7 +21,7 @@ export function registerWeaverseNextComponents(
   ensureNextItemConstructor()
 
   for (let component of components) {
-    let type = component?.schema?.type
+    let type = component.schema.type
     if (type && !registeredComponentTypes.has(type)) {
       Weaverse.registerElement({
         type,

--- a/packages/next/src/registry.ts
+++ b/packages/next/src/registry.ts
@@ -1,0 +1,37 @@
+import { Weaverse } from '@weaverse/react'
+import { ensureNextItemConstructor } from './item'
+import type { WeaverseNextComponent } from './types'
+
+/**
+ * Component lists already pushed into the element registry. Registration is
+ * idempotent, but walking the full list allocates on every call — theme
+ * component arrays are module-level constants, so register each identity once.
+ */
+const registeredComponentLists = new WeakSet<WeaverseNextComponent[]>()
+
+/**
+ * Register Next adapter components with the shared Weaverse element registry.
+ *
+ * This mutates global Weaverse runtime state, so callers should run it while
+ * creating their app/client wiring, not from a React render body.
+ */
+export function registerWeaverseNextComponents(
+  components: WeaverseNextComponent[]
+) {
+  ensureNextItemConstructor()
+
+  if (registeredComponentLists.has(components)) {
+    return
+  }
+  for (let component of components) {
+    if (component?.schema?.type) {
+      Weaverse.registerElement({
+        type: component.schema.type,
+        Component: component.default,
+        schema: component.schema,
+        loader: component.loader,
+      })
+    }
+  }
+  registeredComponentLists.add(components)
+}

--- a/packages/next/src/registry.ts
+++ b/packages/next/src/registry.ts
@@ -1,6 +1,9 @@
 import { Weaverse } from '@weaverse/react'
 import { ensureNextItemConstructor } from './item'
+import { defaultMainComponent } from './main'
 import type { WeaverseNextComponent } from './types'
+
+const MAIN_TYPE = 'main'
 
 /**
  * Component types already pushed into the element registry. Registration is
@@ -14,21 +17,46 @@ const registeredComponentTypes = new Set<string>()
  *
  * This mutates global Weaverse runtime state, so callers should run it while
  * creating their app/client wiring, not from a React render body.
+ *
+ * A default `main` root component is always registered first so consumers don't
+ * have to register one for basic page-tree rendering. If the consumer registers
+ * their own `main`, that one is preferred: we only prepend the default when the
+ * provided components don't already include a `main`, so a user-provided `main`
+ * never collides with (or is shadowed by) the default.
  */
 export function registerWeaverseNextComponents(
   components: WeaverseNextComponent[]
 ) {
   ensureNextItemConstructor()
 
-  for (let component of components) {
+  let hasUserMain = components.some(
+    (component) => component.schema?.type === MAIN_TYPE
+  )
+  let effectiveComponents = hasUserMain
+    ? components
+    : [defaultMainComponent, ...components]
+
+  for (let component of effectiveComponents) {
     let type = component.schema.type
+    let element = {
+      type,
+      Component: component.default,
+      schema: component.schema,
+      loader: component.loader,
+    }
+
+    if (type === MAIN_TYPE && hasUserMain) {
+      // `main` is the only built-in default. If a consumer registers their own
+      // root component after the default was already installed by another
+      // client/test/request, prefer the consumer version by replacing the global
+      // registry entry explicitly.
+      Weaverse.elementRegistry.set(type, element)
+      registeredComponentTypes.add(type)
+      continue
+    }
+
     if (type && !registeredComponentTypes.has(type)) {
-      Weaverse.registerElement({
-        type,
-        Component: component.default,
-        schema: component.schema,
-        loader: component.loader,
-      })
+      Weaverse.registerElement(element)
       registeredComponentTypes.add(type)
     }
   }

--- a/packages/next/src/registry.ts
+++ b/packages/next/src/registry.ts
@@ -3,11 +3,11 @@ import { ensureNextItemConstructor } from './item'
 import type { WeaverseNextComponent } from './types'
 
 /**
- * Component lists already pushed into the element registry. Registration is
- * idempotent, but walking the full list allocates on every call — theme
- * component arrays are module-level constants, so register each identity once.
+ * Component types already pushed into the element registry. Registration is
+ * idempotent by `schema.type`, so callers may pass fresh arrays per request
+ * without causing repeated global registry writes.
  */
-const registeredComponentLists = new WeakSet<WeaverseNextComponent[]>()
+const registeredComponentTypes = new Set<string>()
 
 /**
  * Register Next adapter components with the shared Weaverse element registry.
@@ -20,18 +20,16 @@ export function registerWeaverseNextComponents(
 ) {
   ensureNextItemConstructor()
 
-  if (registeredComponentLists.has(components)) {
-    return
-  }
   for (let component of components) {
-    if (component?.schema?.type) {
+    let type = component?.schema?.type
+    if (type && !registeredComponentTypes.has(type)) {
       Weaverse.registerElement({
-        type: component.schema.type,
+        type,
         Component: component.default,
         schema: component.schema,
         loader: component.loader,
       })
+      registeredComponentTypes.add(type)
     }
   }
-  registeredComponentLists.add(components)
 }

--- a/packages/next/src/renderer.tsx
+++ b/packages/next/src/renderer.tsx
@@ -1,39 +1,15 @@
 'use client'
 
 import { Weaverse, WeaverseRoot } from '@weaverse/react'
-import { memo, useContext } from 'react'
-import { ensureNextItemConstructor } from './item'
+import { memo, useContext, useMemo } from 'react'
 import { WeaverseNextContext } from './provider'
 import type {
   WeaverseNextClient,
-  WeaverseNextComponent,
   WeaverseNextLoaderData,
   WeaverseNextPageData,
 } from './types'
 
-/**
- * Component lists already pushed into the element registry. Registration is
- * idempotent, but walking the full list allocates on every render — theme
- * component arrays are module-level constants, so register each identity once.
- */
-const registeredComponentLists = new WeakSet<WeaverseNextComponent[]>()
-
-function registerComponents(components: WeaverseNextComponent[]) {
-  if (registeredComponentLists.has(components)) {
-    return
-  }
-  for (let component of components) {
-    if (component?.schema?.type) {
-      Weaverse.registerElement({
-        type: component.schema.type,
-        Component: component.default,
-        schema: component.schema,
-        loader: component.loader,
-      })
-    }
-  }
-  registeredComponentLists.add(components)
-}
+const EMPTY_DATA_CONTEXT: Record<string, unknown> = {}
 
 function getRenderablePage(
   data: WeaverseNextLoaderData | null | undefined
@@ -53,8 +29,6 @@ function getRenderablePage(
 export interface WeaverseNextRendererProps {
   /** Client to render from. Defaults to the provider's client. */
   client?: WeaverseNextClient
-  /** Component registry override. Defaults to `client.components`. */
-  components?: WeaverseNextComponent[]
   /** Page payload to render. Defaults to `client.data`. */
   data?: WeaverseNextLoaderData | null
   /** Data-connector context for `{{...}}` template replacement. */
@@ -75,25 +49,33 @@ export const WeaverseNextRenderer = memo(function WeaverseNextRenderer(
   let context = useContext(WeaverseNextContext)
   let client = props.client ?? context?.client
   let data = props.data ?? client?.data ?? null
-  let components = props.components ?? client?.components ?? []
-  let dataContext = props.dataContext ?? client?.dataContext ?? {}
+  let dataContext =
+    props.dataContext ?? client?.dataContext ?? EMPTY_DATA_CONTEXT
 
-  // Mirror Hydrogen: register components before constructing items so the item
-  // store can read each element's schema during creation.
-  ensureNextItemConstructor()
-  registerComponents(components)
+  let page = useMemo(() => getRenderablePage(data), [data])
 
-  let page = getRenderablePage(data)
-  if (!page) {
+  let weaverse = useMemo(() => {
+    if (!page) {
+      return null
+    }
+
+    let instance = new Weaverse({
+      projectId: client?.projectId || page.id || 'weaverse-next',
+      data: page,
+    })
+    instance.dataContext = dataContext
+    instance.isDesignMode = client?.requestContext?.isDesignMode ?? false
+    return instance
+  }, [
+    client?.projectId,
+    client?.requestContext?.isDesignMode,
+    page,
+    dataContext,
+  ])
+
+  if (!weaverse) {
     return null
   }
-
-  let weaverse = new Weaverse({
-    projectId: client?.projectId || page.id || 'weaverse-next',
-    data: page,
-  })
-  weaverse.dataContext = dataContext
-  weaverse.isDesignMode = client?.requestContext?.isDesignMode ?? false
 
   return <WeaverseRoot context={weaverse} />
 })

--- a/packages/next/src/renderer.tsx
+++ b/packages/next/src/renderer.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { Weaverse, WeaverseRoot } from '@weaverse/react'
+import { memo, useContext } from 'react'
+import { ensureNextItemConstructor } from './item'
+import { WeaverseNextContext } from './provider'
+import type {
+  WeaverseNextClient,
+  WeaverseNextComponent,
+  WeaverseNextLoaderData,
+  WeaverseNextPageData,
+} from './types'
+
+/**
+ * Component lists already pushed into the element registry. Registration is
+ * idempotent, but walking the full list allocates on every render — theme
+ * component arrays are module-level constants, so register each identity once.
+ */
+const registeredComponentLists = new WeakSet<WeaverseNextComponent[]>()
+
+function registerComponents(components: WeaverseNextComponent[]) {
+  if (registeredComponentLists.has(components)) {
+    return
+  }
+  for (let component of components) {
+    if (component?.schema?.type) {
+      Weaverse.registerElement({
+        type: component.schema.type,
+        Component: component.default,
+        schema: component.schema,
+        loader: component.loader,
+      })
+    }
+  }
+  registeredComponentLists.add(components)
+}
+
+function getRenderablePage(
+  data: WeaverseNextLoaderData | null | undefined
+): (WeaverseNextPageData & { rootId: string }) | null {
+  let page = data?.page
+  if (!page) {
+    return null
+  }
+  let rootId =
+    page.rootId ??
+    page.items.find((item) => item.type === 'main')?.id ??
+    page.items[0]?.id ??
+    page.id
+  return { ...page, rootId }
+}
+
+export interface WeaverseNextRendererProps {
+  /** Client to render from. Defaults to the provider's client. */
+  client?: WeaverseNextClient
+  /** Component registry override. Defaults to `client.components`. */
+  components?: WeaverseNextComponent[]
+  /** Page payload to render. Defaults to `client.data`. */
+  data?: WeaverseNextLoaderData | null
+  /** Data-connector context for `{{...}}` template replacement. */
+  dataContext?: Record<string, unknown>
+}
+
+/**
+ * Render a serialized Weaverse page tree through `@weaverse/react` primitives.
+ *
+ * Reads the client/page data from {@link WeaverseNextContext} when no props are
+ * passed, or accepts an explicit `client` + `data` for standalone use. Builds a
+ * framework-neutral `Weaverse` core instance (no React Router hooks) and hands
+ * it to the shared `WeaverseRoot`.
+ */
+export const WeaverseNextRenderer = memo(function WeaverseNextRenderer(
+  props: WeaverseNextRendererProps
+) {
+  let context = useContext(WeaverseNextContext)
+  let client = props.client ?? context?.client
+  let data = props.data ?? client?.data ?? null
+  let components = props.components ?? client?.components ?? []
+  let dataContext = props.dataContext ?? client?.dataContext ?? {}
+
+  // Mirror Hydrogen: register components before constructing items so the item
+  // store can read each element's schema during creation.
+  ensureNextItemConstructor()
+  registerComponents(components)
+
+  let page = getRenderablePage(data)
+  if (!page) {
+    return null
+  }
+
+  let weaverse = new Weaverse({
+    projectId: client?.projectId || page.id || 'weaverse-next',
+    data: page,
+  })
+  weaverse.dataContext = dataContext
+  weaverse.isDesignMode = client?.requestContext?.isDesignMode ?? false
+
+  return <WeaverseRoot context={weaverse} />
+})

--- a/packages/next/src/renderer.tsx
+++ b/packages/next/src/renderer.tsx
@@ -43,7 +43,7 @@ export interface WeaverseNextRendererProps {
  * framework-neutral `Weaverse` core instance (no React Router hooks) and hands
  * it to the shared `WeaverseRoot`.
  */
-export const WeaverseNextRenderer = memo(function WeaverseNextRenderer(
+export const WeaverseNextRenderer = memo(function WeaverseNextRendererComponent(
   props: WeaverseNextRendererProps
 ) {
   let context = useContext(WeaverseNextContext)

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -1,0 +1,179 @@
+import type {
+  WeaverseElement,
+  WeaverseResourcePickerData,
+} from '@weaverse/react'
+import type { PageType, SchemaType } from '@weaverse/schema'
+import type { ComponentType, ForwardRefExoticComponent, ReactNode } from 'react'
+
+/**
+ * Locale/market info passed through to component loaders and the Storefront
+ * client. Kept structurally close to Hydrogen's `WeaverseI18n` but without the
+ * `@shopify/hydrogen` `I18nBase` dependency so the adapter stays framework
+ * neutral.
+ */
+export interface WeaverseNextI18n {
+  country?: string
+  label?: string
+  language?: string
+  locale?: string
+  pathPrefix?: string
+  [key: string]: unknown
+}
+
+/**
+ * Minimal Storefront client shape required by component loaders. The host app
+ * provides this (public or private token mode); Weaverse never owns it.
+ */
+export interface WeaverseNextStorefront {
+  i18n?: WeaverseNextI18n
+  query: (query: string, options?: unknown) => Promise<unknown>
+  [key: string]: unknown
+}
+
+/**
+ * App-provided commerce context. `storefront` is the only v0 must-have; cart
+ * and customer-account stay app-owned and are passed through untouched.
+ */
+export interface WeaverseNextCommerceContext {
+  cart?: unknown
+  customerAccount?: unknown
+  storefront?: WeaverseNextStorefront
+  [key: string]: unknown
+}
+
+/**
+ * Explicit, framework-neutral replacement for React Router's
+ * `LoaderFunctionArgs`. Built by the Next route/page from params + headers +
+ * searchParams instead of an implicit loader context.
+ */
+export interface WeaverseNextRequestContext {
+  handle?: string
+  headers?: Headers
+  i18n?: WeaverseNextI18n
+  isDesignMode?: boolean
+  isPreviewMode?: boolean
+  isRevisionPreview?: boolean
+  pageType?: PageType
+  pathname?: string
+  searchParams?: URLSearchParams
+  sectionType?: string
+  url?: URL | string
+  [key: string]: unknown
+}
+
+/** A single serialized item in a Weaverse page tree. */
+export interface WeaverseNextComponentData {
+  children?: WeaverseNextComponentData[] | { id: string }[]
+  data?: Record<string, unknown>
+  id: string
+  /** Attached by {@link runWeaverseComponentLoaders} after a loader runs. */
+  loaderData?: unknown
+  type: string
+  [key: string]: unknown
+}
+
+/** Serialized page tree fetched from Weaverse. */
+export interface WeaverseNextPageData {
+  id: string
+  items: WeaverseNextComponentData[]
+  name?: string
+  rootId?: string
+  [key: string]: unknown
+}
+
+/**
+ * Top-level payload returned by `client.loadPage`. Kept close to Hydrogen's
+ * `WeaverseLoaderData` so registered components stay portable.
+ */
+export interface WeaverseNextLoaderData {
+  configs?: Record<string, unknown>
+  page: WeaverseNextPageData
+  pageAssignment?: Record<string, unknown>
+  project?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+/** Props injected into every registered Weaverse component. */
+export interface WeaverseNextComponentProps<L = unknown>
+  extends Partial<WeaverseElement> {
+  children?: ReactNode
+  className?: string
+  loaderData?: L
+  [key: string]: unknown
+}
+
+/**
+ * Arguments passed to a component `loader`. `commerce.storefront` is the
+ * explicit contract; `weaverse.storefront` exists as a compatibility alias for
+ * Pilot-style loaders that call `weaverse.storefront.query(...)`.
+ */
+export interface WeaverseNextComponentLoaderArgs<TData = unknown> {
+  commerce?: WeaverseNextCommerceContext
+  context?: WeaverseNextRequestContext
+  data: TData
+  weaverse: WeaverseNextClient
+}
+
+/** Registered component module shape: `default` + `schema` + optional `loader`. */
+export interface WeaverseNextComponent<
+  TProps extends WeaverseNextComponentProps = WeaverseNextComponentProps,
+> {
+  default: ComponentType<TProps> | ForwardRefExoticComponent<TProps>
+  loader?: (args: WeaverseNextComponentLoaderArgs) => Promise<unknown>
+  schema: SchemaType
+}
+
+/** Input for `client.loadPage`. The Next route maps `params` → `type/handle`. */
+export interface WeaverseNextLoadPageInput {
+  handle?: string
+  locale?: string
+  type?: PageType
+  [key: string]: unknown
+}
+
+export interface WeaverseNextClientConfig {
+  commerce?: WeaverseNextCommerceContext
+  components: WeaverseNextComponent[]
+  /**
+   * Injected page fetcher. v0 delegates network I/O to the host app so the
+   * adapter can be tested without real Weaverse API calls.
+   */
+  fetchPage?: (
+    input: WeaverseNextLoadPageInput
+  ) => Promise<WeaverseNextLoaderData | null>
+  /** Injected theme-settings fetcher. */
+  fetchThemeSettings?: (
+    context?: WeaverseNextRequestContext
+  ) => Promise<unknown>
+  projectId: string
+  requestContext?: WeaverseNextRequestContext
+  themeSchema?: unknown
+  themeSettings?: Record<string, unknown>
+}
+
+/**
+ * Request-safe client returned by {@link createWeaverseNextClient}. Holds the
+ * registry/config plus the currently loaded page data, and is the object passed
+ * to component loaders as `weaverse`.
+ */
+export interface WeaverseNextClient {
+  commerce?: WeaverseNextCommerceContext
+  components: WeaverseNextComponent[]
+  /** Currently loaded page payload (set by `loadPage`). */
+  data: WeaverseNextLoaderData | null
+  /** Data-connector context handed to the React renderer. */
+  dataContext: Record<string, unknown>
+  loadPage: (
+    input?: WeaverseNextLoadPageInput
+  ) => Promise<WeaverseNextLoaderData | null>
+  loadThemeSettings: (context?: WeaverseNextRequestContext) => Promise<unknown>
+  projectId: string
+  requestContext?: WeaverseNextRequestContext
+  /** Compatibility alias for `commerce.storefront`. */
+  storefront?: WeaverseNextStorefront
+  themeSchema?: unknown
+  themeSettings: Record<string, unknown>
+}
+
+export type WeaverseProduct = WeaverseResourcePickerData
+export type WeaverseCollection = WeaverseResourcePickerData

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1,0 +1,36 @@
+import type { SchemaType } from '@weaverse/schema'
+
+/**
+ * Generate default component data from a schema's `settings` inputs.
+ *
+ * Mirrors Hydrogen's `generateDataFromSchema` (settings → `{ [name]:
+ * defaultValue }`) but is kept local so `@weaverse/next` doesn't depend on
+ * `@weaverse/hydrogen`. Falls back to the deprecated `inspector` array when a
+ * schema predates `settings`.
+ */
+export function generateDataFromSchema(
+  schema: SchemaType | undefined
+): Record<string, unknown> {
+  let data: Record<string, unknown> = {}
+  if (!schema) {
+    return data
+  }
+
+  let groups =
+    (schema.settings as {
+      inputs?: { name?: string; defaultValue?: unknown }[]
+    }[]) ??
+    (schema as { inspector?: typeof groups }).inspector ??
+    []
+
+  for (let group of groups) {
+    for (let input of group?.inputs ?? []) {
+      let { name, defaultValue } = input
+      if (name && defaultValue !== null && defaultValue !== undefined) {
+        data[name] = defaultValue
+      }
+    }
+  }
+
+  return data
+}

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "types": ["node"],
+    "paths": {
+      "~/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*", "__tests__/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/next/vitest.config.ts
+++ b/packages/next/vitest.config.ts
@@ -2,9 +2,11 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const packageRoot = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(packageRoot, '../..')
 
 export default defineConfig({
+  root: packageRoot,
   resolve: {
     alias: {
       react: resolve(repoRoot, 'node_modules/react'),
@@ -14,6 +16,6 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['packages/next/**/*.{test,spec}.{ts,tsx}'],
+    include: ['__tests__/**/*.{test,spec}.{ts,tsx}'],
   },
 })

--- a/packages/next/vitest.config.ts
+++ b/packages/next/vitest.config.ts
@@ -1,0 +1,19 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      react: resolve(repoRoot, 'node_modules/react'),
+      'react-dom': resolve(repoRoot, 'node_modules/react-dom'),
+    },
+    dedupe: ['react', 'react-dom'],
+  },
+  test: {
+    environment: 'node',
+    include: ['packages/next/**/*.{test,spec}.{ts,tsx}'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,12 @@ importers:
       '@weaverse/schema':
         specifier: 0.10.0
         version: 0.10.0
+      react:
+        specifier: '>=19'
+        version: 19.2.5
+      react-dom:
+        specifier: '>=19'
+        version: 19.2.5(react@19.2.5)
     peerDependencies:
       react:
         specifier: '>=19'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,13 @@ importers:
       '@weaverse/schema':
         specifier: 0.10.0
         version: 0.10.0
+    peerDependencies:
+      react:
+        specifier: '>=19'
+        version: 19.2.5
+      react-dom:
+        specifier: '>=19'
+        version: 19.2.5(react@19.2.5)
 
   packages/react:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,15 @@ importers:
         specifier: ^19.2.13
         version: 19.2.14
 
+  packages/next:
+    dependencies:
+      '@weaverse/react':
+        specifier: 5.16.3
+        version: 5.16.3
+      '@weaverse/schema':
+        specifier: 0.10.0
+        version: 0.10.0
+
   packages/react:
     dependencies:
       '@weaverse/core':


### PR DESCRIPTION
## Summary

Adds the first `@weaverse/next` v0 package shell for the Next.js App Router adapter contract from Weaverse/builder#2533.

This slice intentionally focuses on contract shape and test-backed renderer/loader mechanics, not production Weaverse API network I/O.

## What changed

- Created `packages/next` workspace package.
- Added `createWeaverseNextClient` with injected `fetchPage` / `fetchThemeSettings` fetchers.
- Added `WeaverseNextProvider` with explicit root/page/commerce data instead of React Router loader emulation.
- Added `WeaverseNextRenderer` using `@weaverse/react` renderer primitives.
- Added `runWeaverseComponentLoaders` with explicit `commerce.storefront` and `weaverse.storefront` compatibility alias.
- Re-exported schema helpers and runtime hooks for migration ergonomics.
- Added tests for provider hooks, loader execution, renderer fixture, and package boundary guard.
- Added Claude handoff + work-log updates in the adapter contract spec folder.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @weaverse/next test` — 9 tests passed
- `pnpm --filter @weaverse/next typecheck`
- `pnpm --filter @weaverse/next build`
- `pnpm run biome -- packages/next`
- `pnpm exec turbo run typecheck --filter=@weaverse/next`
- `pnpm exec turbo run build --filter=@weaverse/next`
- `autoreview-copilot --mode local` — clean after fixing client-boundary/memoization findings

## Notes

- React/ReactDOM are peer dependencies to avoid duplicate React instances with `@weaverse/react`.
- `next` is not a dependency yet because this v0 shell does not import `next/*`.
- Network I/O remains host-app injected via fetchers; production API fetcher is a follow-up slice.
