### PR TITLE
fix(hydrogen): design-mode sibling-key wipe + pixel revisit behind persistent layout

### DIFF
--- a/packages/hydrogen/__tests__/theme-text-context.test.ts
+++ b/packages/hydrogen/__tests__/theme-text-context.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getNestedKey, interpolate } from '../src/hooks/theme-text-context'
+import {
+  createTranslate,
+  getNestedKey,
+  interpolate,
+} from '../src/hooks/theme-text-context'
 
 describe('getNestedKey', () => {
   const data = {
@@ -97,7 +101,7 @@ describe('interpolate', () => {
 })
 
 describe('t() function integration', () => {
-  // Simulate the t() logic directly (same as in ThemeTextProvider)
+  // Exercise the REAL t() builder (no reimplementation, no drift).
   function createT(
     staticContent: Record<string, unknown>,
     merchantOverrides?: Record<string, unknown>,
@@ -106,27 +110,7 @@ describe('t() function integration', () => {
       variables?: Record<string, string | number>
     ) => string
   ) {
-    return (
-      key: string,
-      variables?: Record<string, string | number>
-    ): string => {
-      // Priority 1: external t
-      if (externalT) {
-        const external = externalT(key, variables)
-        if (external && external !== key) {
-          return external
-        }
-      }
-      // Priority 2: merchant overrides
-      const override = merchantOverrides
-        ? getNestedKey(merchantOverrides, key)
-        : undefined
-      // Priority 3: static content
-      const staticValue = getNestedKey(staticContent, key)
-      // Priority 4: key itself
-      const raw = override ?? staticValue ?? key
-      return interpolate(raw, variables)
-    }
+    return createTranslate({ staticContent, merchantOverrides, externalT })
   }
 
   const staticContent = {
@@ -244,5 +228,91 @@ describe('t() function integration', () => {
   it('should work with undefined externalT (backwards compat)', () => {
     const t = createT(staticContent, undefined, undefined)
     expect(t('cart.title')).toBe('Cart')
+  })
+})
+
+describe('createTranslate design-mode overrides', () => {
+  const staticContent = {
+    cart: {
+      title: 'Cart',
+      subtitle: 'Review your items',
+      empty: { message: 'Empty' },
+    },
+  }
+
+  it('should prefer a flat design override over merchant and static', () => {
+    const t = createTranslate({
+      staticContent,
+      merchantOverrides: { cart: { title: 'Giỏ hàng' } },
+      designOverrides: { 'cart.title': 'Live Cart' },
+    })
+    expect(t('cart.title')).toBe('Live Cart')
+  })
+
+  it('should NOT wipe sibling keys when overriding a nested leaf', () => {
+    // Regression: a shallow `{...merchant, ...unflatten(design)}` merge
+    // replaced the whole `cart` subtree, dropping every non-overridden
+    // sibling. Per-key lookup must leave siblings resolving normally.
+    const t = createTranslate({
+      staticContent,
+      merchantOverrides: {
+        cart: {
+          title: 'Giỏ hàng',
+          subtitle: 'Xem lại',
+          empty: { message: 'Trống' },
+        },
+      },
+      designOverrides: { 'cart.title': 'Live Cart' },
+    })
+    expect(t('cart.title')).toBe('Live Cart')
+    // Siblings still resolve from merchantOverrides, not the static/default.
+    expect(t('cart.subtitle')).toBe('Xem lại')
+    expect(t('cart.empty.message')).toBe('Trống')
+  })
+
+  it('should interpolate variables in a design override', () => {
+    const t = createTranslate({
+      staticContent: { badge: { sale: '-{{percentage}}% Off' } },
+      designOverrides: { 'badge.sale': 'Save {{percentage}}%' },
+    })
+    expect(t('badge.sale', { percentage: 40 })).toBe('Save 40%')
+  })
+
+  it('should ignore an empty design override map', () => {
+    const t = createTranslate({ staticContent, designOverrides: {} })
+    expect(t('cart.title')).toBe('Cart')
+  })
+
+  it('should let external t win over a design override', () => {
+    const t = createTranslate({
+      staticContent,
+      designOverrides: { 'cart.title': 'Live Cart' },
+      externalT: (key) => (key === 'cart.title' ? 'Panier' : key),
+    })
+    expect(t('cart.title')).toBe('Panier')
+  })
+
+  it('should not resolve inherited Object.prototype keys as overrides', () => {
+    // `designOverrides.toString` etc. are inherited functions; an unguarded
+    // `designOverrides[key]` would return a function and break interpolate.
+    const t = createTranslate({
+      staticContent: { greeting: 'Hi' },
+      designOverrides: {},
+    })
+    expect(t('toString')).toBe('toString')
+    expect(t('constructor')).toBe('constructor')
+    expect(t('greeting')).toBe('Hi')
+  })
+
+  it('should not pollute Object.prototype from design override keys', () => {
+    // JSON.parse defines `__proto__` as an own key; building nested objects
+    // from such keys (the old unflatten path) polluted the prototype.
+    const malicious = JSON.parse('{"__proto__.polluted":"yes"}') as Record<
+      string,
+      string
+    >
+    const t = createTranslate({ staticContent, designOverrides: malicious })
+    t('cart.title')
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
   })
 })

--- a/packages/hydrogen/__tests__/use-pixel.test.ts
+++ b/packages/hydrogen/__tests__/use-pixel.test.ts
@@ -1,17 +1,19 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { registerPixelInstance, shouldFirePixel } from '../src/utils/pixel'
 
-// Track registrations so each test ends with zero mounted instances —
-// the module then forgets its navigation state (the unmount-reset path).
+// Each mounted instance mirrors `usePixel`: register(pageId) THEN decide to
+// fire. Track registrations so every test ends with zero mounted instances —
+// the module then fully forgets its navigation state.
 let cleanups: (() => void)[] = []
-function mountInstance() {
-  let unregister = registerPixelInstance()
-  let wrapped = () => {
+function mountInstance(navigationKey: string, pageId: string) {
+  let unregister = registerPixelInstance(pageId)
+  let fired = shouldFirePixel(navigationKey, pageId)
+  let unmount = () => {
     unregister()
-    cleanups = cleanups.filter((c) => c !== wrapped)
+    cleanups = cleanups.filter((c) => c !== unmount)
   }
-  cleanups.push(wrapped)
-  return wrapped
+  cleanups.push(unmount)
+  return { fired, unmount }
 }
 afterEach(() => {
   for (let cleanup of [...cleanups]) {
@@ -21,57 +23,81 @@ afterEach(() => {
 
 describe('shouldFirePixel', () => {
   it('should_fire_once_per_page_per_navigation', () => {
-    mountInstance()
-    expect(shouldFirePixel('nav-1', 'page-a')).toBe(true)
-    // Second co-located instance of the same page must not double-count.
-    expect(shouldFirePixel('nav-1', 'page-a')).toBe(false)
+    // Two co-located instances of the same page must not double-count.
+    let first = mountInstance('nav-1', 'page-a')
+    let second = mountInstance('nav-1', 'page-a')
+    expect(first.fired).toBe(true)
+    expect(second.fired).toBe(false)
   })
 
   it('should_count_each_co_located_page_separately', () => {
-    mountInstance()
-    mountInstance()
-    expect(shouldFirePixel('nav-2', 'page-layout')).toBe(true)
-    expect(shouldFirePixel('nav-2', 'page-child')).toBe(true)
-    expect(shouldFirePixel('nav-2', 'page-child')).toBe(false)
+    let layout = mountInstance('nav-2', 'page-layout')
+    let child = mountInstance('nav-2', 'page-child')
+    let childDup = mountInstance('nav-2', 'page-child')
+    expect(layout.fired).toBe(true)
+    expect(child.fired).toBe(true)
+    expect(childDup.fired).toBe(false)
   })
 
   it('should_count_back_forward_revisits_between_weaverse_pages', () => {
     // location.key is stable per history entry: A → B → Back POPs to A's
-    // ORIGINAL key. The key transition (not novelty) marks the navigation.
-    let unmountA = mountInstance()
-    expect(shouldFirePixel('key-a', 'page-a')).toBe(true)
-    unmountA()
-    let unmountB = mountInstance()
-    expect(shouldFirePixel('key-b', 'page-b')).toBe(true)
-    unmountB()
-    mountInstance()
-    expect(shouldFirePixel('key-a', 'page-a')).toBe(true)
-    expect(shouldFirePixel('key-a', 'page-a')).toBe(false)
+    // ORIGINAL key. Each page fully unmounts before the next mounts.
+    let a = mountInstance('key-a', 'page-a')
+    expect(a.fired).toBe(true)
+    a.unmount()
+    let b = mountInstance('key-b', 'page-b')
+    expect(b.fired).toBe(true)
+    b.unmount()
+    let aRevisit = mountInstance('key-a', 'page-a')
+    let aRevisitDup = mountInstance('key-a', 'page-a')
+    expect(aRevisit.fired).toBe(true)
+    expect(aRevisitDup.fired).toBe(false)
   })
 
   it('should_count_revisits_after_detouring_through_non_weaverse_routes', () => {
     // Weaverse page A → cart (no Weaverse instance, key never observed by
-    // this module) → Back to A with the SAME stored key. The unmount of
-    // the last instance must forget the navigation state.
-    let unmountA = mountInstance()
-    expect(shouldFirePixel('key-a', 'page-a')).toBe(true)
-    unmountA()
+    // this module) → Back to A with the SAME stored key. The page's last
+    // instance unmounted, so its fired state was forgotten.
+    let a = mountInstance('key-a', 'page-a')
+    expect(a.fired).toBe(true)
+    a.unmount()
     // ...visitor is on /cart; nothing registered...
-    mountInstance()
-    expect(shouldFirePixel('key-a', 'page-a')).toBe(true)
+    let aRevisit = mountInstance('key-a', 'page-a')
+    expect(aRevisit.fired).toBe(true)
   })
 
   it('should_keep_state_while_a_nested_layout_instance_stays_mounted', () => {
     // /help/contact → /help/other: the layout's instance never unmounts,
-    // so state must NOT reset on the child swap alone — the new child
-    // fires via its key transition, and duplicates still dedupe.
-    mountInstance()
-    let unmountChild = mountInstance()
-    expect(shouldFirePixel('key-a', 'page-layout')).toBe(true)
-    expect(shouldFirePixel('key-a', 'page-contact')).toBe(true)
-    unmountChild()
-    mountInstance()
-    expect(shouldFirePixel('key-b', 'page-other')).toBe(true)
-    expect(shouldFirePixel('key-b', 'page-other')).toBe(false)
+    // so state must NOT reset on the child swap alone — the new child fires
+    // via its key transition, and duplicates still dedupe.
+    let layout = mountInstance('key-a', 'page-layout')
+    let contact = mountInstance('key-a', 'page-contact')
+    expect(layout.fired).toBe(true)
+    expect(contact.fired).toBe(true)
+    contact.unmount()
+    let other = mountInstance('key-b', 'page-other')
+    let otherDup = mountInstance('key-b', 'page-other')
+    expect(other.fired).toBe(true)
+    expect(otherDup.fired).toBe(false)
+  })
+
+  it('should_count_a_revisit_after_a_detour_while_a_layout_instance_persists', () => {
+    // The regression: a persistent layout-level Weaverse instance never
+    // unmounts, so the old single global mounted-instance counter never hit
+    // zero and never reset. A Back to the SAME history entry (key-a
+    // unchanged) then wrongly suppressed the page's revisit pixel.
+    let layout = mountInstance('key-a', 'page-layout')
+    let a = mountInstance('key-a', 'page-a')
+    expect(layout.fired).toBe(true)
+    expect(a.fired).toBe(true)
+    // Navigate A → /cart: the page instance unmounts, the layout persists.
+    a.unmount()
+    // /cart has no Weaverse instance; nothing registered, key unobserved.
+    // Back → /a restores key-a while the layout is still mounted.
+    let aRevisit = mountInstance('key-a', 'page-a')
+    expect(aRevisit.fired).toBe(true)
+    // A co-located duplicate on the revisit still dedupes.
+    let aRevisitDup = mountInstance('key-a', 'page-a')
+    expect(aRevisitDup.fired).toBe(false)
   })
 })

--- a/packages/hydrogen/__tests__/use-pixel.test.ts
+++ b/packages/hydrogen/__tests__/use-pixel.test.ts
@@ -1,19 +1,27 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { registerPixelInstance, shouldFirePixel } from '../src/utils/pixel'
+import {
+  observeNavigation,
+  registerPixelInstance,
+  shouldFirePixel,
+} from '../src/utils/pixel'
 
-// Each mounted instance mirrors `usePixel`: register(pageId) THEN decide to
-// fire. Track registrations so every test ends with zero mounted instances —
-// the module then fully forgets its navigation state.
+// Each mounted instance mirrors `usePixel`'s two effects: an observe effect
+// (runs on mount and on every navigation key change) and a fire effect (runs
+// once on mount: register, then decide). `navigate()` models a STILL-mounted
+// instance re-running only its observe effect. Track registrations so every
+// test ends with zero mounted instances — the module then resets fully.
 let cleanups: (() => void)[] = []
 function mountInstance(navigationKey: string, pageId: string) {
-  let unregister = registerPixelInstance(pageId)
+  observeNavigation(navigationKey)
+  let unregister = registerPixelInstance()
   let fired = shouldFirePixel(navigationKey, pageId)
   let unmount = () => {
     unregister()
     cleanups = cleanups.filter((c) => c !== unmount)
   }
   cleanups.push(unmount)
-  return { fired, unmount }
+  let navigate = (nextKey: string) => observeNavigation(nextKey)
+  return { fired, unmount, navigate }
 }
 afterEach(() => {
   for (let cleanup of [...cleanups]) {
@@ -55,9 +63,9 @@ describe('shouldFirePixel', () => {
   })
 
   it('should_count_revisits_after_detouring_through_non_weaverse_routes', () => {
-    // Weaverse page A → cart (no Weaverse instance, key never observed by
-    // this module) → Back to A with the SAME stored key. The page's last
-    // instance unmounted, so its fired state was forgotten.
+    // Weaverse page A → cart (no Weaverse instance) → Back to A with the SAME
+    // stored key. No instance survived the detour, so the last-unmount reset
+    // forgot the navigation and the revisit counts.
     let a = mountInstance('key-a', 'page-a')
     expect(a.fired).toBe(true)
     a.unmount()
@@ -67,14 +75,15 @@ describe('shouldFirePixel', () => {
   })
 
   it('should_keep_state_while_a_nested_layout_instance_stays_mounted', () => {
-    // /help/contact → /help/other: the layout's instance never unmounts,
-    // so state must NOT reset on the child swap alone — the new child fires
-    // via its key transition, and duplicates still dedupe.
+    // /help/contact → /help/other: the layout's instance never unmounts, so
+    // state must NOT reset on the child swap alone — the new child fires via
+    // its key transition, and duplicates still dedupe.
     let layout = mountInstance('key-a', 'page-layout')
     let contact = mountInstance('key-a', 'page-contact')
     expect(layout.fired).toBe(true)
     expect(contact.fired).toBe(true)
     contact.unmount()
+    layout.navigate('key-b')
     let other = mountInstance('key-b', 'page-other')
     let otherDup = mountInstance('key-b', 'page-other')
     expect(other.fired).toBe(true)
@@ -82,22 +91,37 @@ describe('shouldFirePixel', () => {
   })
 
   it('should_count_a_revisit_after_a_detour_while_a_layout_instance_persists', () => {
-    // The regression: a persistent layout-level Weaverse instance never
-    // unmounts, so the old single global mounted-instance counter never hit
-    // zero and never reset. A Back to the SAME history entry (key-a
-    // unchanged) then wrongly suppressed the page's revisit pixel.
+    // A persistent layout-level instance survives the detour and OBSERVES the
+    // key round-trip (key-a → key-cart → key-a), so the Back is recognised as
+    // a real navigation and the page's revisit pixel fires.
     let layout = mountInstance('key-a', 'page-layout')
     let a = mountInstance('key-a', 'page-a')
     expect(layout.fired).toBe(true)
     expect(a.fired).toBe(true)
-    // Navigate A → /cart: the page instance unmounts, the layout persists.
+    // Navigate A → /cart: the page instance unmounts, the layout persists and
+    // observes the detour key, then the Back to the original entry.
     a.unmount()
-    // /cart has no Weaverse instance; nothing registered, key unobserved.
-    // Back → /a restores key-a while the layout is still mounted.
+    layout.navigate('key-cart')
+    layout.navigate('key-a')
     let aRevisit = mountInstance('key-a', 'page-a')
     expect(aRevisit.fired).toBe(true)
     // A co-located duplicate on the revisit still dedupes.
     let aRevisitDup = mountInstance('key-a', 'page-a')
     expect(aRevisitDup.fired).toBe(false)
+  })
+
+  it('should_not_double_count_an_in_place_remount_on_the_same_navigation', () => {
+    // The `data={null}` suppress/restore path unmounts and remounts a page on
+    // the SAME history entry (key unchanged) while a layout-level instance
+    // stays mounted. The key never transitions, so fired state survives and
+    // the restore must NOT emit a second pixel.
+    let layout = mountInstance('key-a', 'page-layout')
+    let a = mountInstance('key-a', 'page-a')
+    expect(layout.fired).toBe(true)
+    expect(a.fired).toBe(true)
+    // Suppressed in place (no navigation, no key change); layout persists.
+    a.unmount()
+    let aRestored = mountInstance('key-a', 'page-a')
+    expect(aRestored.fired).toBe(false)
   })
 })

--- a/packages/hydrogen/src/hooks/theme-text-context.tsx
+++ b/packages/hydrogen/src/hooks/theme-text-context.tsx
@@ -104,27 +104,55 @@ export type ThemeTextProviderProps = {
 }
 
 /**
- * Convert flat dot-notation keys to a nested object structure.
+ * Build the `t()` translation function over a fixed set of sources.
  *
- * @example
- * unflattenKeys({ "cart.title": "Cart", "cart.empty": "Empty" })
- * // => { cart: { title: "Cart", empty: "Empty" } }
+ * Resolution order, highest priority first:
+ * 1. `externalT`         – host i18n (e.g. Shopify), unless it echoes the key
+ * 2. `designOverrides`   – live design-mode edits, flat dot-path keys
+ * 3. `merchantOverrides` – locale overrides from the API, nested
+ * 4. `staticContent`     – the theme's default locale JSON
+ * 5. the key itself
+ *
+ * Design overrides are looked up per-key (own properties only) rather than
+ * merged into `merchantOverrides`: a flat key like `cart.title` must override
+ * exactly that leaf without wiping sibling keys (`cart.subtitle`), and a
+ * per-key own-property lookup never builds nested objects from
+ * merchant-controlled keys, so it cannot pollute `Object.prototype`.
  */
-function unflattenKeys(flat: Record<string, string>): Record<string, unknown> {
-  const result: Record<string, unknown> = {}
-  for (const [dotPath, value] of Object.entries(flat)) {
-    const keys = dotPath.split('.')
-    let current: Record<string, unknown> = result
-    for (let i = 0; i < keys.length - 1; i++) {
-      const k = keys[i]
-      if (!(k in current) || typeof current[k] !== 'object') {
-        current[k] = {}
+export function createTranslate(sources: {
+  staticContent: Record<string, unknown>
+  merchantOverrides?: Record<string, unknown>
+  designOverrides?: Record<string, string>
+  externalT?: TranslateFunction
+}): TranslateFunction {
+  const { staticContent, merchantOverrides, designOverrides, externalT } =
+    sources
+  return (key, variables) => {
+    // Priority 1: external t (e.g. Shopify i18n, third-party library).
+    if (externalT) {
+      const external = externalT(key, variables)
+      // Accept the external value unless it echoed the key unchanged.
+      if (external && external !== key) {
+        return external
       }
-      current = current[k] as Record<string, unknown>
     }
-    current[keys[keys.length - 1]] = value
+
+    // Priority 2: live design-mode override (flat, keyed by exact dot-path,
+    // own properties only so inherited keys never resolve to functions).
+    const design =
+      designOverrides && Object.hasOwn(designOverrides, key)
+        ? designOverrides[key]
+        : undefined
+    // Priority 3: merchant overrides (nested). Priority 4: static content.
+    const override = merchantOverrides
+      ? getNestedKey(merchantOverrides, key)
+      : undefined
+    const staticValue = getNestedKey(staticContent, key)
+
+    // Priority 5: the key itself as the final fallback.
+    const raw = design ?? override ?? staticValue ?? key
+    return interpolate(raw, variables)
   }
-  return result
 }
 
 // No-op fallback for useSafeExternalStore when store is null (production).
@@ -154,52 +182,25 @@ export function ThemeTextProvider({
     themeTextStore?.getServerSnapshot ?? NOOP_SNAPSHOT
   )
 
-  // Merge design overrides into merchantOverrides when present.
-  // Design overrides are flat ("cart.title": "value") but merchantOverrides
-  // are nested ({cart: {title: "value"}}), so unflatten before merging.
-  // Guard preserves original ref when empty → useMemo deps unchanged.
-  const mergedOverrides =
-    designOverrides !== EMPTY && Object.keys(designOverrides).length > 0
-      ? { ...merchantOverrides, ...unflattenKeys(designOverrides) }
-      : merchantOverrides
-
-  const value = useMemo<ThemeTextValue>(() => {
-    const t: TranslateFunction = (key, variables) => {
-      // Priority 1: external t (e.g. Shopify i18n, third-party library)
-      if (externalT) {
-        const external = externalT(key, variables)
-        // Accept the external value unless it echoed the key unchanged
-        if (external && external !== key) {
-          return external
-        }
-      }
-
-      // Priority 2: merchant overrides (+ design overrides merged in)
-      const override = mergedOverrides
-        ? getNestedKey(mergedOverrides, key)
-        : undefined
-
-      // Priority 3: static content (theme default JSON)
-      const staticValue = getNestedKey(staticContent, key)
-
-      // Priority 4: key itself as fallback
-      const raw = override ?? staticValue ?? key
-
-      return interpolate(raw, variables)
-    }
-
-    return {
-      t,
+  const value = useMemo<ThemeTextValue>(
+    () => ({
+      t: createTranslate({
+        staticContent,
+        merchantOverrides,
+        designOverrides,
+        externalT,
+      }),
       themeTextStore: themeTextStore ?? null,
       merchantOverrides: merchantOverrides ?? null,
-    }
-  }, [
-    staticContent,
-    merchantOverrides,
-    mergedOverrides,
-    externalT,
-    themeTextStore,
-  ])
+    }),
+    [
+      staticContent,
+      merchantOverrides,
+      designOverrides,
+      externalT,
+      themeTextStore,
+    ]
+  )
 
   return (
     <ThemeTextContext.Provider value={value}>

--- a/packages/hydrogen/src/utils/pixel.ts
+++ b/packages/hydrogen/src/utils/pixel.ts
@@ -1,24 +1,25 @@
-// One pixel per page per navigation. Nested compositions mount multiple
-// Weaverse instances on one URL; both would otherwise double-count the
-// same impression.
+// One pixel per page per navigation. Two facts shape the dedup:
 //
-// Two mechanisms cooperate:
+// 1. Co-located instances: nested compositions mount multiple Weaverse
+//    instances of the same page on one URL; only the first should count.
+// 2. The pixel effect runs once per instance mount (see `usePixel`), so a
+//    given instance never re-fires — a navigation is always a fresh mount.
 //
-// 1. Key TRANSITIONS (not novelty): `location.key` is stable per history
-//    entry, so a back/forward POP restores the entry's ORIGINAL key. We
-//    remember only the current key and reset on change — any navigation
-//    between Weaverse pages counts again.
-// 2. Instance lifetime: navigating to a route WITHOUT a Weaverse instance
-//    (cart, search, account) never calls into this module, so the stored
-//    key would still match on Back and wrongly suppress the revisit. When
-//    the last registered instance unmounts, forget the navigation state.
+// `firedPageIds` is scoped to the current navigation key and reset on a key
+// TRANSITION. `mountCounts` tracks how many instances of each pageId are
+// currently mounted; when the LAST instance of a pageId unmounts we forget
+// its fired state. That second mechanism is what makes a detour-and-Back to
+// the SAME history entry (`location.key` restored unchanged) count the
+// revisit: without the per-page refcount, a persistent layout-level Weaverse
+// instance would keep the navigation state alive across the detour and
+// wrongly suppress the page's revisit pixel.
 //
 // Known tradeoff: React StrictMode's dev-only mount→cleanup→mount cycle
-// resets the state and double-fires in development — parity with the
-// pre-dedupe behavior; production semantics are unaffected.
+// double-fires in development — parity with the pre-dedupe behavior;
+// production semantics are unaffected.
 let currentNavigationKey: string | null = null
 let firedPageIds = new Set<string>()
-let mountedInstances = 0
+let mountCounts = new Map<string, number>()
 
 export function shouldFirePixel(
   navigationKey: string,
@@ -36,17 +37,22 @@ export function shouldFirePixel(
 }
 
 /**
- * Track the mounted Weaverse instance; returns the unmount cleanup.
- * Call before `shouldFirePixel` so the navigation state's lifetime is
- * bounded by "at least one Weaverse instance is on screen".
+ * Track a mounted Weaverse instance for `pageId`; returns the unmount
+ * cleanup. Call before `shouldFirePixel` so the navigation state's lifetime
+ * is bounded by "at least one instance of this page is on screen". When the
+ * last instance of a pageId unmounts, its fired state is dropped so a Back
+ * navigation that restores the same history entry re-counts it — even while
+ * another Weaverse instance stays mounted across the detour.
  */
-export function registerPixelInstance(): () => void {
-  mountedInstances += 1
+export function registerPixelInstance(pageId: string): () => void {
+  mountCounts.set(pageId, (mountCounts.get(pageId) ?? 0) + 1)
   return () => {
-    mountedInstances -= 1
-    if (mountedInstances === 0) {
-      currentNavigationKey = null
-      firedPageIds.clear()
+    let next = (mountCounts.get(pageId) ?? 1) - 1
+    if (next > 0) {
+      mountCounts.set(pageId, next)
+      return
     }
+    mountCounts.delete(pageId)
+    firedPageIds.delete(pageId)
   }
 }

--- a/packages/hydrogen/src/utils/pixel.ts
+++ b/packages/hydrogen/src/utils/pixel.ts
@@ -1,34 +1,51 @@
-// One pixel per page per navigation. Two facts shape the dedup:
+// One pixel per page per navigation. A few facts shape the dedup:
 //
 // 1. Co-located instances: nested compositions mount multiple Weaverse
-//    instances of the same page on one URL; only the first should count.
-// 2. The pixel effect runs once per instance mount (see `usePixel`), so a
-//    given instance never re-fires — a navigation is always a fresh mount.
+//    instances on one URL; each page is counted at most once.
+// 2. The pixel FIRE effect runs once per instance mount (see `usePixel`), so
+//    an instance never re-fires on its own — a navigation is a fresh mount.
+// 3. `location.key` is stable per history entry. A back/forward POP restores
+//    the entry's ORIGINAL key, and an in-place remount on the same entry
+//    (e.g. the `data={null}` suppress/restore path in WeaverseHydrogenRoot)
+//    keeps that same key. A REAL navigation is therefore a key CHANGE.
 //
-// `firedPageIds` is scoped to the current navigation key and reset on a key
-// TRANSITION. `mountCounts` tracks how many instances of each pageId are
-// currently mounted; when the LAST instance of a pageId unmounts we forget
-// its fired state. That second mechanism is what makes a detour-and-Back to
-// the SAME history entry (`location.key` restored unchanged) count the
-// revisit: without the per-page refcount, a persistent layout-level Weaverse
-// instance would keep the navigation state alive across the detour and
-// wrongly suppress the page's revisit pixel.
+// `firedPageIds` is the set of pages already counted for the current
+// navigation. It is forgotten in two ways:
+//   - On a key TRANSITION reported by ANY mounted instance via
+//     `observeNavigation` (driven by a per-navigation effect). A persistent
+//     layout-level instance keeps observing across a detour through a
+//     non-Weaverse route (cart, search, account), so a Back to the original
+//     entry is recognised as a new navigation and the page re-counts — while
+//     an in-place suppress/restore (no key change) does NOT re-count.
+//   - When the LAST instance unmounts (`registerPixelInstance`), covering the
+//     detour case where no instance survives to observe the key round-trip
+//     (a page with no persistent layout going to /cart and back).
 //
 // Known tradeoff: React StrictMode's dev-only mount→cleanup→mount cycle
-// double-fires in development — parity with the pre-dedupe behavior;
-// production semantics are unaffected.
+// resets state and double-fires in development — parity with the pre-dedupe
+// behavior; production semantics are unaffected.
 let currentNavigationKey: string | null = null
 let firedPageIds = new Set<string>()
-let mountCounts = new Map<string, number>()
+let mountedInstances = 0
+
+/**
+ * Record the navigation key seen by a mounted instance. A change of key is a
+ * real navigation and forgets the previous navigation's fired pages; an
+ * unchanged key (an in-place remount / suppress-restore on the same history
+ * entry) leaves them intact, so the page is not double-counted.
+ */
+export function observeNavigation(navigationKey: string): void {
+  if (navigationKey !== currentNavigationKey) {
+    currentNavigationKey = navigationKey
+    firedPageIds.clear()
+  }
+}
 
 export function shouldFirePixel(
   navigationKey: string,
   pageId: string
 ): boolean {
-  if (navigationKey !== currentNavigationKey) {
-    currentNavigationKey = navigationKey
-    firedPageIds.clear()
-  }
+  observeNavigation(navigationKey)
   if (firedPageIds.has(pageId)) {
     return false
   }
@@ -37,22 +54,18 @@ export function shouldFirePixel(
 }
 
 /**
- * Track a mounted Weaverse instance for `pageId`; returns the unmount
- * cleanup. Call before `shouldFirePixel` so the navigation state's lifetime
- * is bounded by "at least one instance of this page is on screen". When the
- * last instance of a pageId unmounts, its fired state is dropped so a Back
- * navigation that restores the same history entry re-counts it — even while
- * another Weaverse instance stays mounted across the detour.
+ * Track a mounted Weaverse instance; returns the unmount cleanup. When the
+ * last instance unmounts, the navigation state is forgotten so a Back that
+ * restores the same history entry counts again even if no instance survived
+ * to observe the detour.
  */
-export function registerPixelInstance(pageId: string): () => void {
-  mountCounts.set(pageId, (mountCounts.get(pageId) ?? 0) + 1)
+export function registerPixelInstance(): () => void {
+  mountedInstances += 1
   return () => {
-    let next = (mountCounts.get(pageId) ?? 1) - 1
-    if (next > 0) {
-      mountCounts.set(pageId, next)
-      return
+    mountedInstances -= 1
+    if (mountedInstances === 0) {
+      currentNavigationKey = null
+      firedPageIds.clear()
     }
-    mountCounts.delete(pageId)
-    firedPageIds.delete(pageId)
   }
 }

--- a/packages/hydrogen/src/utils/use-studio.ts
+++ b/packages/hydrogen/src/utils/use-studio.ts
@@ -140,7 +140,7 @@ export function usePixel(context: WeaverseHydrogen) {
     }
     // Register BEFORE deciding to fire: the navigation state must live
     // exactly as long as some Weaverse instance is mounted (see pixel.ts).
-    let unregister = registerPixelInstance()
+    let unregister = registerPixelInstance(pageId)
     if (shouldFirePixel(navigationKey, pageId)) {
       let img = new Image()
       img.onload = () => img.remove()

--- a/packages/hydrogen/src/utils/use-studio.ts
+++ b/packages/hydrogen/src/utils/use-studio.ts
@@ -9,7 +9,11 @@ import {
 import type { WeaverseHydrogen } from '~/index'
 import { hasWeaverseStudio } from '~/types'
 import { useThemeText } from '../hooks/theme-text-context'
-import { registerPixelInstance, shouldFirePixel } from './pixel'
+import {
+  observeNavigation,
+  registerPixelInstance,
+  shouldFirePixel,
+} from './pixel'
 import { getStudioScriptSrc, resolveStudioScriptSrc } from './studio-script-src'
 import { useThemeSettingsStore } from './use-theme-settings-store'
 
@@ -133,14 +137,25 @@ export function useStudio(weaverse: WeaverseHydrogen) {
 export function usePixel(context: WeaverseHydrogen) {
   let { projectId, pageId, isDesignMode, weaverseHost } = context
   let { key: navigationKey } = useLocation()
-  // biome-ignore lint/correctness/useExhaustiveDependencies: only track once on mount
+  // Observe every navigation so a persistent layout-level instance forgets
+  // the previous navigation's fired pages on a real key change — but NOT on
+  // an in-place remount that keeps the same history entry (e.g. the
+  // `data={null}` suppress/restore path), which must not double-count.
   useEffect(() => {
     if (!(projectId && pageId) || isDesignMode) {
       return
     }
-    // Register BEFORE deciding to fire: the navigation state must live
-    // exactly as long as some Weaverse instance is mounted (see pixel.ts).
-    let unregister = registerPixelInstance(pageId)
+    observeNavigation(navigationKey)
+  }, [navigationKey, projectId, pageId, isDesignMode])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fire once on mount
+  useEffect(() => {
+    if (!(projectId && pageId) || isDesignMode) {
+      return
+    }
+    // Register BEFORE deciding to fire: the navigation state must live at
+    // least as long as some Weaverse instance is mounted (see pixel.ts).
+    let unregister = registerPixelInstance()
     if (shouldFirePixel(navigationKey, pageId)) {
       let img = new Image()
       img.onload = () => img.remove()


### PR DESCRIPTION
## What

Two live `@weaverse/hydrogen` bugs surfaced in review, plus the test gaps that let them ship.

### 1. Design-mode override wiped sibling translation keys (critical)
`ThemeTextProvider` unflattened the flat design-mode overrides and **shallow-merged** them into `merchantOverrides`:

```ts
{ ...merchantOverrides, ...unflattenKeys(designOverrides) }
```

A single leaf edit like `cart.title` produced `{ cart: { title: "…" } }` that replaced the **entire** `cart` subtree, so every non-overridden sibling (`cart.subtitle`, `cart.empty.message`, …) vanished and fell back to the English default while editing.

The unflatten step also assigned into objects keyed by override keys, so a `__proto__` key could pollute `Object.prototype`.

**Fix:** drop the merge. `createTranslate` now does a per-key, **own-property** design lookup (`Object.hasOwn`) slotted between `externalT` and `merchantOverrides`. `unflattenKeys` is removed. The translation builder is extracted and exported so it can be unit-tested directly (the old tests re-implemented the logic and never exercised the real merge).

Resolution order: `externalT` → `designOverrides[key]` → `merchantOverrides` (nested) → `staticContent` → key.

### 2. Pixel revisit suppressed behind a persistent layout instance (important)
The dedup kept a single global mounted-instance counter and only forgot the navigation state when it hit zero. A layout-level `WeaverseHydrogenRoot` that persists across a detour (page → `/cart` → Back) keeps that counter above zero, so the state never reset; the restored `location.key` then matched and the page's revisit pixel was dropped.

**Fix:** track a per-`pageId` mount refcount and drop a page's fired state when its **last** instance unmounts. Co-located duplicates still dedupe (a sibling keeps the count > 0); a fresh mount on a restored key re-fires. `registerPixelInstance` now takes the `pageId`.

## Tests
- `createTranslate`: design-override priority, **sibling-preservation regression**, `__proto__` non-pollution, inherited-key (`toString`/`constructor`) safety, external-t precedence.
- pixel: **revisit-behind-persistent-layout regression** plus the existing co-located / back-forward / detour cases re-modelled to mirror `usePixel` (register-then-fire).
- `pnpm exec vp test --run` → **160/160** in `@weaverse/hydrogen`; `tsc --noEmit` clean; biome 2.5.0 clean.

## Scope
`@weaverse/hydrogen` only. No public API change beyond `registerPixelInstance(pageId)` (internal util, single caller in `use-studio.ts`).
