### PR TITLE
Add Next Studio runtime bridge

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,0 +1,142 @@
+# @weaverse/next
+
+Next.js App Router integration for building Weaverse-powered storefronts.
+
+This package adapts the Weaverse runtime (component registry, page-tree
+rendering, Studio bridge) to Next.js without depending on React Router or
+Hydrogen. It mirrors the `@weaverse/hydrogen` contract where it makes sense, but
+takes plain, framework-neutral inputs (URL, headers, search params) instead of a
+React Router `Request`/`LoaderFunctionArgs`.
+
+## Entrypoints
+
+| Import | Use in | Purpose |
+| --- | --- | --- |
+| `@weaverse/next` | Client & server | Registry, renderer, provider, hooks, Studio runtime/bridge. |
+| `@weaverse/next/server` | Server only | Server-side Weaverse client that fetches page/theme data from the Weaverse API. |
+
+> The server-side data-loading API lives under **`@weaverse/next/server`** so the
+> root entry stays free of server-only fetch assumptions and safe to import from
+> client components.
+
+## Package structure
+
+```text
+packages/next/src/
+  index.ts              # root (@weaverse/next) public exports
+  server.ts             # server (@weaverse/next/server) public exports
+  client.ts             # createWeaverseNextClient (injected-fetcher client)
+  loader.ts             # runWeaverseComponentLoaders (server-side section loaders)
+  registry.ts           # register components with the Weaverse element registry
+  renderer.tsx          # WeaverseNextRenderer (page-tree → React)
+  provider.tsx          # WeaverseNextProvider (client context for hooks)
+  hooks.ts              # useThemeSettings / useWeaversePageData / ...
+  runtime.ts            # WeaverseNextRuntime + Studio binding
+  studio-bridge.tsx     # Studio script injection / connect
+  request-info.ts       # buildWeaverseNextRequestInfo (Studio-compatible)
+  theme-settings-store.ts
+  types.ts              # shared types (root + server)
+  server/
+    server-client.ts    # createWeaverseNextServerClient
+    configs.ts          # getWeaverseNextConfigs (host/api-base/flags/env)
+    normalize-page-url.ts
+```
+
+## Root API (`@weaverse/next`)
+
+- `createWeaverseNextClient(config)` — request-safe client that delegates network
+  I/O to injected `fetchPage` / `fetchThemeSettings`.
+- `WeaverseNextProvider` / `WeaverseNextRenderer` — client provider + page-tree
+  renderer.
+- `runWeaverseComponentLoaders(args)` — walk a page tree and run each registered
+  component's `loader` server-side.
+- Hooks: `useThemeSettings`, `useWeaversePageData`, `useWeaverseRootData`,
+  `useWeaverseCommerce` (plus re-exported `@weaverse/react` hooks).
+- Studio helpers: `WeaverseNextRuntime`, `createWeaverseNextRuntime`,
+  `bindWeaverseNextStudioRuntime`, `WeaverseNextStudioBridge`,
+  `WeaverseNextStudioConnect`, `resolveWeaverseNextStudioScriptSrc`,
+  `buildWeaverseNextRequestInfo`, `createWeaverseNextThemeSettingsStore`.
+- `createSchema` (re-exported from `@weaverse/schema`).
+
+## Server API (`@weaverse/next/server`)
+
+`createWeaverseNextServerClient(config)` returns a client that performs the real
+Weaverse public API fetch — the equivalent of Hydrogen's
+`context.weaverse.loadPage(...)`.
+
+```ts
+import { createWeaverseNextServerClient } from '@weaverse/next/server'
+import { components } from '@/weaverse/components'
+
+export async function loadWeaverse(request: Request, storefront: Storefront) {
+  let url = new URL(request.url)
+  let weaverse = createWeaverseNextServerClient({
+    projectId: process.env.WEAVERSE_PROJECT_ID, // string | (ctx) => string | Promise<string>
+    components,
+    themeSchema,
+    commerce: { storefront },
+    env: process.env,
+    requestContext: {
+      url,
+      headers: request.headers,
+      searchParams: url.searchParams,
+      i18n: storefront.i18n,
+    },
+    cache: { revalidate: 60, tags: ['weaverse'] },
+  })
+
+  let [page, theme] = await Promise.all([
+    weaverse.loadPage({ type: 'INDEX' }),
+    weaverse.loadThemeSettings(),
+  ])
+  return { page, theme, weaverse }
+}
+```
+
+### Returned client
+
+| Member | Description |
+| --- | --- |
+| `loadPage(input?)` | POSTs `{ projectId, url, i18n, params, isDesignMode }` to `/api/public/project`, runs component loaders, returns `WeaverseNextLoaderData` (`page`, `project`, `pageAssignment`, `configs.requestInfo`). In Studio preview mode (`?isPreviewMode=true`) it short-circuits to a synthetic single-section page built from the `sectionType` presets — no fetch, no `projectId` required. A route-level `projectId` override is propagated to `client.projectId`, loaders, and the returned `configs`. |
+| `loadThemeSettings(options?)` | POSTs to `/api/public/project_configs`, merges `themeSchema` defaults under `theme`, includes `staticContent`; falls back to defaults on failure. |
+| `fetchWithCache<T>(url, options?)` | Mode-aware fetch: `cache: 'no-store'` in design/revision, `next: { revalidate, tags }` in published mode. |
+| `projectId` / `resolveProjectId()` | Resolved project id (query → function → string → env). |
+| `components`, `commerce`, `storefront`, `requestContext`, `themeSchema`, `themeSettings`, `data`, `dataContext`, `configs` | Readonly request state. `storefront` aliases `commerce.storefront`. |
+
+### Config resolution
+
+Close to Hydrogen's `getWeaverseConfigs`:
+
+- **projectId** — `?weaverseProjectId=` query → config function → config string →
+  `WEAVERSE_PROJECT_ID` env.
+- **weaverseHost** — trusted request `?weaverseHost=` (only `weaverse.io` /
+  `weaverse.dev` over https) → `WEAVERSE_HOST` env → `https://studio.weaverse.io`.
+- **API base** — trusted request host → `WEAVERSE_PUBLIC_API_BASE` env → custom
+  non-production `WEAVERSE_HOST` → `https://api.weaverse.io`.
+- **publicEnv** — `PUBLIC_STORE_DOMAIN`, `PUBLIC_STOREFRONT_API_TOKEN`.
+
+`WEAVERSE_API_KEY` is read from the request query / env and kept on the internal
+base configs, but the current server client does **not** attach it to the
+page/theme API requests. It is also **never** serialized into client-facing
+`configs` / loader data, so it cannot leak to the browser.
+
+## Studio helpers
+
+Design/preview detection, the Studio bridge script, and the in-page runtime are
+shared with the root entry: `createWeaverseNextRuntime` + `WeaverseNextProvider`
+hydrate Studio, and `bindWeaverseNextStudioRuntime` wires live updates. The
+server client emits `configs.requestInfo` and design-mode flags the bridge
+expects.
+
+## Current limitations
+
+- Server fetch has a timeout + single attempt; it does not yet replicate
+  Hydrogen's subrequest cache, retry/backoff, or merchant-overrides translation
+  fetch.
+- Next caching is expressed only via `cache: 'no-store'` and
+  `next: { revalidate, tags }`; on-demand `revalidatePath`/`revalidateTag` is left
+  to the host app.
+- `loadCustomPages` (sitemap) and SEO helpers are not ported yet.
+- The Studio bridge currently reuses the Hydrogen bundle until a Next-specific
+  bundle is required.
+- Package is pre-release (`alpha`); the API may still change.

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -128,6 +128,13 @@ hydrate Studio, and `bindWeaverseNextStudioRuntime` wires live updates. The
 server client emits `configs.requestInfo` and design-mode flags the bridge
 expects.
 
+> **Mount `WeaverseNextStudioConnect` at your root/client shell.**
+> `WeaverseNextRenderer` mounts the in-page runtime bridge but does **not**
+> inject the Studio bridge script by itself. The script (which lets Studio's
+> `checkWeaversePage()` handshake answer on every route, including content-less
+> ones) is loaded by `WeaverseNextStudioConnect`, so it must be rendered once at
+> the app root/client shell for the Studio editor to connect.
+
 ## Current limitations
 
 - Server fetch has a timeout + single attempt; it does not yet replicate

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -753,7 +753,7 @@ describe('Studio runtime contract', () => {
     vi.stubGlobal('window', previousWindow)
   })
 
-  it('should_call_studio_init_once_then_refresh_for_reused_runtime', () => {
+  it('should_refresh_studio_after_reusing_runtime_with_new_page_data', () => {
     // Arrange
     let previousWindow = globalThis.window
     let init = vi.fn()
@@ -766,20 +766,30 @@ describe('Studio runtime contract', () => {
       requestContext: { isDesignMode: true, pathname: '/' },
     })
     let runtime = createWeaverseNextRuntime({ client, data: makePageData() })
+    bindWeaverseNextStudioRuntime(runtime)
+    let nextData = {
+      ...makePageData(),
+      page: {
+        ...makePageData().page,
+        items: [
+          ...makePageData().page.items,
+          { id: 'section-2', type: 'hero', data: { heading: 'Updated' } },
+        ],
+      },
+    }
 
     // Act
-    bindWeaverseNextStudioRuntime(runtime)
-    bindWeaverseNextStudioRuntime(runtime)
+    let reusedRuntime = createWeaverseNextRuntime({ client, data: nextData })
+    bindWeaverseNextStudioRuntime(reusedRuntime)
 
     // Assert
+    expect(reusedRuntime).toBe(runtime)
     expect(init).toHaveBeenCalledTimes(1)
-    expect(init).toHaveBeenCalledWith(runtime)
-    expect(refreshStudio).toHaveBeenCalledTimes(1)
     expect(refreshStudio).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: runtime.data,
+        data: reusedRuntime.data,
         pageId: 'page-1',
-        requestInfo: runtime.requestInfo,
+        requestInfo: reusedRuntime.requestInfo,
       })
     )
     vi.stubGlobal('window', previousWindow)

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -709,6 +709,70 @@ describe('Studio runtime contract', () => {
     )
   })
 
+  it('should_trust_non_studio_weaverse_subdomains_for_script_src', () => {
+    // Arrange — a non-`studio` subdomain of a trusted apex domain, matching
+    // Hydrogen's subdomain trust.
+    let searchParams = new URLSearchParams(
+      'isDesignMode=true&weaverseHost=https%3A%2F%2Fpreview.weaverse.dev'
+    )
+
+    // Act
+    let src = resolveWeaverseNextStudioScriptSrc(
+      { searchParams },
+      { storefrontHostname: 'shop.example' }
+    )
+
+    // Assert
+    expect(src).toBe(
+      'https://preview.weaverse.dev/static/studio/hydrogen/index.js'
+    )
+  })
+
+  it('should_reject_untrusted_weaverse_host_for_script_src', () => {
+    // Arrange
+    let searchParams = new URLSearchParams(
+      'isDesignMode=true&weaverseHost=https%3A%2F%2Fweaverse.io.evil.example'
+    )
+
+    // Act
+    let src = resolveWeaverseNextStudioScriptSrc(
+      { searchParams },
+      { storefrontHostname: 'shop.example' }
+    )
+
+    // Assert
+    expect(src).toBeNull()
+  })
+
+  it('should_trust_loopback_studio_host_only_when_storefront_is_loopback', () => {
+    // Arrange
+    let searchParams = new URLSearchParams(
+      'isDesignMode=true&weaverseHost=http%3A%2F%2Flocalhost%3A3000'
+    )
+
+    // Act — loopback storefront opts into the loopback host (local builder).
+    let loopbackSrc = resolveWeaverseNextStudioScriptSrc(
+      { searchParams },
+      { storefrontHostname: 'localhost' }
+    )
+    // Same crafted host on a public storefront must be rejected.
+    let publicSrc = resolveWeaverseNextStudioScriptSrc(
+      { searchParams },
+      { storefrontHostname: 'shop.example' }
+    )
+    // Omitting storefrontHostname must also be safe-by-default, not loopback.
+    let omittedStorefrontSrc = resolveWeaverseNextStudioScriptSrc({
+      searchParams,
+    })
+
+    // Assert
+    expect(loopbackSrc).toBe(
+      'http://localhost:3000/static/studio/hydrogen/index.js'
+    )
+    expect(publicSrc).toBeNull()
+    expect(omittedStorefrontSrc).toBeNull()
+  })
+
   it('should_create_studio_runtime_with_request_info_and_internal_contract', () => {
     // Arrange
     let previousWindow = globalThis.window
@@ -792,6 +856,72 @@ describe('Studio runtime contract', () => {
         requestInfo: reusedRuntime.requestInfo,
       })
     )
+    vi.stubGlobal('window', previousWindow)
+  })
+
+  it('should_not_clobber_studio_drafts_when_reusing_runtime_in_design_mode', () => {
+    // Arrange — a live design-mode runtime owns the page tree (incl. unsaved
+    // drafts); reusing it with fresh loader data must not replace that tree.
+    let previousWindow = globalThis.window
+    let fakeWindow = {} as Window &
+      typeof globalThis & { __weaverses?: unknown }
+    vi.stubGlobal('window', fakeWindow)
+    let client = makeClient({
+      requestContext: { isDesignMode: true, pathname: '/' },
+    })
+    let runtime = createWeaverseNextRuntime({ client, data: makePageData() })
+    let setProjectData = vi.spyOn(runtime, 'setProjectData')
+    let nextData = {
+      ...makePageData(),
+      page: {
+        ...makePageData().page,
+        items: [
+          ...makePageData().page.items,
+          { id: 'section-2', type: 'hero', data: { heading: 'Server data' } },
+        ],
+      },
+    }
+
+    // Act
+    let reusedRuntime = createWeaverseNextRuntime({ client, data: nextData })
+
+    // Assert — same runtime, draft tree untouched, no project-data reset.
+    expect(reusedRuntime).toBe(runtime)
+    expect(setProjectData).not.toHaveBeenCalled()
+    expect(reusedRuntime.data.items).toHaveLength(1)
+    vi.stubGlobal('window', previousWindow)
+  })
+
+  it('should_apply_fresh_page_data_when_reusing_runtime_outside_design_mode', () => {
+    // Arrange — published/non-design reuse has no draft state, so the latest
+    // loader data must win.
+    let previousWindow = globalThis.window
+    let fakeWindow = {} as Window &
+      typeof globalThis & { __weaverses?: unknown }
+    vi.stubGlobal('window', fakeWindow)
+    let client = makeClient({
+      requestContext: { isDesignMode: false, pathname: '/' },
+    })
+    let runtime = createWeaverseNextRuntime({ client, data: makePageData() })
+    let setProjectData = vi.spyOn(runtime, 'setProjectData')
+    let nextData = {
+      ...makePageData(),
+      page: {
+        ...makePageData().page,
+        items: [
+          ...makePageData().page.items,
+          { id: 'section-2', type: 'hero', data: { heading: 'Server data' } },
+        ],
+      },
+    }
+
+    // Act
+    let reusedRuntime = createWeaverseNextRuntime({ client, data: nextData })
+
+    // Assert — same runtime, but the fresh page tree is applied.
+    expect(reusedRuntime).toBe(runtime)
+    expect(setProjectData).toHaveBeenCalledTimes(1)
+    expect(reusedRuntime.data.items).toHaveLength(2)
     vi.stubGlobal('window', previousWindow)
   })
 })

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -4,8 +4,13 @@ import type { ReactNode, RefObject } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  bindWeaverseNextStudioRuntime,
+  buildWeaverseNextRequestInfo,
   createSchema,
   createWeaverseNextClient,
+  createWeaverseNextRuntime,
+  createWeaverseNextThemeSettingsStore,
+  resolveWeaverseNextStudioScriptSrc,
   runWeaverseComponentLoaders,
   useThemeSettings,
   useWeaverseCommerce,
@@ -634,5 +639,149 @@ describe('package boundaries', () => {
 
     // Assert
     expect(offenders).toEqual([])
+  })
+})
+
+// ─── 6. Studio runtime contract ───────────────────────────────────────
+
+describe('Studio runtime contract', () => {
+  it('should_build_request_info_from_url_and_search_params', () => {
+    // Arrange
+    let searchParams = new URLSearchParams(
+      'isDesignMode=true&isPreviewMode=false&foo=old&foo=new'
+    )
+
+    // Act
+    let requestInfo = buildWeaverseNextRequestInfo({
+      i18n: { country: 'US', language: 'EN' },
+      pathname: '/products/hat',
+      searchParams,
+      url: 'https://shop.example/products/hat?ignored=yes',
+    })
+
+    // Assert
+    expect(requestInfo).toEqual({
+      pathname: '/products/hat',
+      search: '?isDesignMode=true&isPreviewMode=false&foo=old&foo=new',
+      queries: { isDesignMode: true, isPreviewMode: false, foo: 'new' },
+      i18n: { country: 'US', language: 'EN' },
+    })
+  })
+
+  it('should_expose_theme_settings_store_with_live_update_method', () => {
+    // Arrange
+    let listener = vi.fn()
+    let store = createWeaverseNextThemeSettingsStore({
+      publicEnv: { PUBLIC_KEY: 'safe' },
+      schema: { type: 'theme' },
+      settings: { heading: 'Before' },
+    })
+
+    // Act
+    let unsubscribe = store.subscribe(listener)
+    store.updateThemeSettings({ heading: 'After' })
+    unsubscribe()
+    store.updateThemeSettings({ heading: 'Ignored listener' })
+
+    // Assert
+    expect(store.schema).toEqual({ type: 'theme' })
+    expect(store.publicEnv).toEqual({ PUBLIC_KEY: 'safe' })
+    expect(store.getSnapshot()).toEqual({ heading: 'Ignored listener' })
+    expect(store.getServerSnapshot()).toEqual({ heading: 'Ignored listener' })
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('should_use_last_duplicate_studio_control_params_for_script_src', () => {
+    // Arrange
+    let searchParams = new URLSearchParams(
+      'isDesignMode=false&isDesignMode=true&weaverseHost=https%3A%2F%2Fevil.example&weaverseHost=https%3A%2F%2Fstudio.weaverse.io&weaverseVersion=old&weaverseVersion=new'
+    )
+
+    // Act
+    let src = resolveWeaverseNextStudioScriptSrc(
+      { searchParams },
+      { storefrontHostname: 'shop.example' }
+    )
+
+    // Assert
+    expect(src).toBe(
+      'https://studio.weaverse.io/static/studio/hydrogen/index.js?v=new'
+    )
+  })
+
+  it('should_create_studio_runtime_with_request_info_and_internal_contract', () => {
+    // Arrange
+    let previousWindow = globalThis.window
+    let fakeWindow = {} as Window &
+      typeof globalThis & { __weaverses?: unknown }
+    vi.stubGlobal('window', fakeWindow)
+    let client = makeClient({
+      requestContext: {
+        isDesignMode: true,
+        pathname: '/',
+        searchParams: new URLSearchParams('isDesignMode=true'),
+      },
+      themeSchema: { type: 'theme' },
+      themeSettings: { color: 'blue' },
+    })
+    let data = {
+      ...makePageData(),
+      pageAssignment: { type: 'INDEX' },
+      project: { id: 'project-record' },
+    }
+
+    // Act
+    let runtime = createWeaverseNextRuntime({ client, data })
+
+    // Assert
+    expect(runtime.pageId).toBe('page-1')
+    expect(runtime.projectId).toBe('proj-test')
+    expect(runtime.isDesignMode).toBe(true)
+    expect(runtime.requestInfo).toEqual({
+      pathname: '/',
+      search: '?isDesignMode=true',
+      queries: { isDesignMode: true },
+    })
+    expect(runtime.internal.project).toEqual({ id: 'project-record' })
+    expect(runtime.internal.pageAssignment).toEqual({ type: 'INDEX' })
+    expect(runtime.internal.themeSettingsStore?.settings).toEqual({
+      color: 'blue',
+    })
+    expect((fakeWindow.__weaverses as Record<string, unknown>)['page-1']).toBe(
+      runtime
+    )
+    vi.stubGlobal('window', previousWindow)
+  })
+
+  it('should_call_studio_init_once_then_refresh_for_reused_runtime', () => {
+    // Arrange
+    let previousWindow = globalThis.window
+    let init = vi.fn()
+    let refreshStudio = vi.fn()
+    let fakeWindow = {
+      weaverseStudio: { init, refreshStudio },
+    } as unknown as Window & typeof globalThis
+    vi.stubGlobal('window', fakeWindow)
+    let client = makeClient({
+      requestContext: { isDesignMode: true, pathname: '/' },
+    })
+    let runtime = createWeaverseNextRuntime({ client, data: makePageData() })
+
+    // Act
+    bindWeaverseNextStudioRuntime(runtime)
+    bindWeaverseNextStudioRuntime(runtime)
+
+    // Assert
+    expect(init).toHaveBeenCalledTimes(1)
+    expect(init).toHaveBeenCalledWith(runtime)
+    expect(refreshStudio).toHaveBeenCalledTimes(1)
+    expect(refreshStudio).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: runtime.data,
+        pageId: 'page-1',
+        requestInfo: runtime.requestInfo,
+      })
+    )
+    vi.stubGlobal('window', previousWindow)
   })
 })

--- a/packages/next/__tests__/next-server.test.tsx
+++ b/packages/next/__tests__/next-server.test.tsx
@@ -1,0 +1,496 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSchema } from '../src/index'
+import * as serverEntry from '../src/server'
+import { createWeaverseNextServerClient } from '../src/server'
+import type {
+  WeaverseNextComponentLoaderArgs,
+  WeaverseNextComponentProps,
+} from '../src/types'
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function jsonResponse(data: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: async () => data,
+  } as unknown as Response
+}
+
+/** A `fetch` double that records calls and returns a queued payload. */
+function makeFetch(payload: unknown, { ok = true, status = 200 } = {}) {
+  return vi.fn(async () =>
+    jsonResponse(payload, ok, status)
+  ) as unknown as typeof fetch & { mock: { calls: unknown[][] } }
+}
+
+const Hero = (props: WeaverseNextComponentProps) => (
+  <section>{props.heading as string}</section>
+)
+Hero.displayName = 'Hero'
+const heroComponent = {
+  default: Hero,
+  schema: createSchema({ type: 'hero', title: 'Hero' }),
+}
+
+function makePagePayload() {
+  return {
+    page: {
+      id: 'page-1',
+      rootId: 'item-root',
+      items: [{ id: 'item-root', type: 'hero', data: { heading: 'Hi' } }],
+    },
+    project: { id: 'project-record', name: 'Shop', weaverseShopId: 'shop-1' },
+    pageAssignment: { type: 'INDEX' },
+  }
+}
+
+// ─── 1. projectId resolution priority ─────────────────────────────────
+
+describe('createWeaverseNextServerClient projectId resolution', () => {
+  it('should_prefer_query_param_over_function_string_and_env', async () => {
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: () => 'from-function',
+      env: { WEAVERSE_PROJECT_ID: 'from-env' },
+      requestContext: {
+        searchParams: new URLSearchParams('weaverseProjectId=from-query'),
+      },
+    })
+    expect(await client.resolveProjectId()).toBe('from-query')
+    expect(client.projectId).toBe('from-query')
+  })
+
+  it('should_prefer_function_over_string_and_env_and_support_async', async () => {
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: async () => 'from-async-function',
+      env: { WEAVERSE_PROJECT_ID: 'from-env' },
+    })
+    expect(await client.resolveProjectId()).toBe('from-async-function')
+  })
+
+  it('should_use_static_string_when_no_query_or_function', async () => {
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'static-id',
+      env: { WEAVERSE_PROJECT_ID: 'from-env' },
+    })
+    expect(await client.resolveProjectId()).toBe('static-id')
+    expect(client.projectId).toBe('static-id')
+  })
+
+  it('should_fall_back_to_env_when_nothing_else_provided', async () => {
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      env: { WEAVERSE_PROJECT_ID: 'from-env' },
+    })
+    expect(await client.resolveProjectId()).toBe('from-env')
+  })
+})
+
+// ─── 2. loadPage request + response shape ─────────────────────────────
+
+describe('createWeaverseNextServerClient loadPage', () => {
+  it('should_post_expected_url_body_and_return_configs_requestInfo', async () => {
+    let fetchMock = makeFetch(makePagePayload())
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+      requestContext: {
+        url: 'https://shop.example/products/hat?utm_source=x',
+        i18n: { country: 'US', language: 'EN' },
+      },
+    })
+
+    let data = await client.loadPage({ type: 'PRODUCT', handle: 'hat' })
+
+    // Endpoint
+    let [calledUrl, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(calledUrl).toBe('https://api.weaverse.io/api/public/project')
+    expect(init.method).toBe('POST')
+
+    // Body: tracking params stripped from url; params forwarded; projectId set.
+    let body = JSON.parse(init.body as string)
+    expect(body.projectId).toBe('proj-123')
+    expect(body.url).toBe('https://shop.example/products/hat')
+    expect(body.params).toEqual({ type: 'PRODUCT', handle: 'hat' })
+    expect(body.i18n).toEqual({ country: 'US', language: 'EN' })
+    expect(body.isDesignMode).toBe(false)
+
+    // Returned loader data carries Studio-compatible requestInfo + public config.
+    expect(data?.page.id).toBe('page-1')
+    expect(data?.project).toEqual({
+      id: 'project-record',
+      name: 'Shop',
+      weaverseShopId: 'shop-1',
+    })
+    let configs = data?.configs as Record<string, unknown>
+    expect(configs.projectId).toBe('proj-123')
+    // requestInfo mirrors the *actual* request (tracking params kept); only the
+    // API body url above is normalized.
+    expect(configs.requestInfo).toEqual({
+      pathname: '/products/hat',
+      search: '?utm_source=x',
+      queries: { utm_source: 'x' },
+      i18n: { country: 'US', language: 'EN' },
+    })
+    // Server secret must never appear in client-facing configs.
+    expect(configs.weaverseApiKey).toBeUndefined()
+  })
+
+  it('should_use_no_store_cache_in_design_mode', async () => {
+    let fetchMock = makeFetch(makePagePayload())
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+      cache: { revalidate: 120, tags: ['weaverse'] },
+      requestContext: { url: 'https://shop.example/', isDesignMode: true },
+    })
+
+    await client.loadPage()
+
+    let [, init] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit & { next?: unknown },
+    ]
+    expect(init.cache).toBe('no-store')
+    expect(init.next).toBeUndefined()
+    expect(JSON.parse(init.body as string).isDesignMode).toBe(true)
+  })
+
+  it('should_use_configured_next_revalidate_and_tags_in_published_mode', async () => {
+    let fetchMock = makeFetch(makePagePayload())
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+      cache: { revalidate: 120, tags: ['weaverse'] },
+      requestContext: { url: 'https://shop.example/' },
+    })
+
+    await client.loadPage()
+
+    let [, init] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit & { next?: { revalidate?: number; tags?: string[] } },
+    ]
+    expect(init.cache).toBeUndefined()
+    expect(init.next).toEqual({ revalidate: 120, tags: ['weaverse'] })
+  })
+
+  it('should_run_component_loader_with_weaverse_storefront_alias', async () => {
+    let queryResult = { products: [{ id: 1 }] }
+    let query = vi.fn().mockResolvedValue(queryResult)
+    let storefront = { query, i18n: { country: 'US', language: 'EN' } }
+    let received: WeaverseNextComponentLoaderArgs | null = null
+
+    let featured = {
+      default: Hero,
+      schema: createSchema({ type: 'featured', title: 'Featured' }),
+      loader: async (args: WeaverseNextComponentLoaderArgs) => {
+        received = args
+        await args.weaverse.storefront?.query('query Alias { id }')
+        return queryResult
+      },
+    }
+    let fetchMock = makeFetch({
+      page: {
+        id: 'page-1',
+        items: [{ id: 'f1', type: 'featured', data: {} }],
+      },
+      project: { id: 'p', name: 'Shop', weaverseShopId: 's' },
+    })
+    let client = createWeaverseNextServerClient({
+      components: [featured],
+      projectId: 'proj-123',
+      commerce: { storefront },
+      fetch: fetchMock,
+      requestContext: { url: 'https://shop.example/' },
+    })
+
+    let data = await client.loadPage()
+
+    expect(received).not.toBeNull()
+    expect(
+      (received as unknown as WeaverseNextComponentLoaderArgs).weaverse
+        .storefront
+    ).toBe(storefront)
+    expect(query).toHaveBeenCalledWith('query Alias { id }')
+    expect(data?.page.items[0].loaderData).toEqual(queryResult)
+  })
+
+  it('should_return_fallback_page_when_payload_has_no_page', async () => {
+    let fetchMock = makeFetch({
+      project: { id: 'p', name: 'Shop', weaverseShopId: 's' },
+    })
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+      requestContext: { url: 'https://shop.example/' },
+    })
+
+    let data = await client.loadPage()
+    expect(data?.page.items[0].type).toBe('main')
+  })
+
+  it('should_return_null_when_fetch_fails', async () => {
+    let error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let fetchMock = vi
+      .fn()
+      .mockRejectedValue(new Error('network down')) as unknown as typeof fetch
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+      requestContext: { url: 'https://shop.example/' },
+    })
+
+    expect(await client.loadPage()).toBeNull()
+    error.mockRestore()
+  })
+
+  it('should_propagate_route_level_projectId_to_client_loader_and_configs', async () => {
+    let received: WeaverseNextComponentLoaderArgs | null = null
+    let featured = {
+      default: Hero,
+      schema: createSchema({ type: 'featured', title: 'Featured' }),
+      loader: async (args: WeaverseNextComponentLoaderArgs) => {
+        received = args
+        return {}
+      },
+    }
+    let fetchMock = makeFetch({
+      page: { id: 'page-1', items: [{ id: 'f1', type: 'featured', data: {} }] },
+      project: { id: 'p', name: 'Shop', weaverseShopId: 's' },
+    })
+    let client = createWeaverseNextServerClient({
+      components: [featured],
+      projectId: 'client-id',
+      fetch: fetchMock,
+      requestContext: { url: 'https://shop.example/' },
+    })
+
+    let data = await client.loadPage({ projectId: 'route-id' })
+
+    // Request body targets the route override, not the client default.
+    let [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(init.body as string).projectId).toBe('route-id')
+
+    // client.projectId, loader's `weaverse.projectId`, and returned configs all
+    // reflect the override.
+    expect(client.projectId).toBe('route-id')
+    expect(
+      (received as unknown as WeaverseNextComponentLoaderArgs).weaverse
+        .projectId
+    ).toBe('route-id')
+    expect((data?.configs as Record<string, unknown>).projectId).toBe(
+      'route-id'
+    )
+  })
+})
+
+// ─── 2b. preview mode ─────────────────────────────────────────────────
+
+describe('createWeaverseNextServerClient preview mode', () => {
+  it('should_return_synthetic_preview_data_without_fetching', async () => {
+    let fetchMock = makeFetch(makePagePayload())
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+      requestContext: {
+        url: 'https://shop.example/?isPreviewMode=true&sectionType=hero',
+      },
+    })
+
+    let data = await client.loadPage()
+
+    // No page fetch in preview mode.
+    expect(
+      (fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls
+    ).toHaveLength(0)
+
+    expect(data?.page.id).toBe('weaverse-preview-page')
+    let configs = data?.configs as Record<string, unknown>
+    expect(configs.isPreviewMode).toBe(true)
+    expect(configs.weaverseHost).toBe('https://studio.weaverse.io')
+    expect(configs.requestInfo).toBeDefined()
+
+    // The requested section is materialized under the `main` root.
+    let main = data?.page.items.find((item) => item.type === 'main')
+    expect((main?.children as { id: string }[])?.length).toBe(1)
+    expect(data?.page.items.some((item) => item.type === 'hero')).toBe(true)
+  })
+
+  it('should_work_in_preview_mode_without_a_projectId', async () => {
+    let fetchMock = makeFetch(makePagePayload())
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      fetch: fetchMock,
+      requestContext: {
+        isPreviewMode: true,
+        sectionType: 'hero',
+        url: 'https://shop.example/',
+      },
+    })
+
+    let data = await client.loadPage()
+
+    expect(
+      (fetchMock as unknown as { mock: { calls: unknown[] } }).mock.calls
+    ).toHaveLength(0)
+    expect(data).not.toBeNull()
+    // Harmless placeholder id when no real project is resolved.
+    expect(data?.project?.id).toBe('x')
+    expect((data?.configs as Record<string, unknown>).isPreviewMode).toBe(true)
+  })
+})
+
+// ─── 3. loadThemeSettings ─────────────────────────────────────────────
+
+const themeSchema = {
+  type: 'theme',
+  settings: [
+    {
+      group: 'Layout',
+      inputs: [
+        { type: 'range', name: 'pageWidth', defaultValue: 1200 },
+        { type: 'text', name: 'topbarText', defaultValue: 'Default topbar' },
+      ],
+    },
+  ],
+  i18n: { staticContent: { greeting: 'Hello' } },
+}
+
+describe('createWeaverseNextServerClient loadThemeSettings', () => {
+  it('should_merge_schema_defaults_with_remote_overrides_and_static_content', async () => {
+    let fetchMock = makeFetch({ theme: { topbarText: 'Remote topbar' } })
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      themeSchema,
+      fetch: fetchMock,
+      requestContext: { url: 'https://shop.example/' },
+    })
+
+    let result = await client.loadThemeSettings()
+
+    let [calledUrl, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(calledUrl).toBe('https://api.weaverse.io/api/public/project_configs')
+    expect(JSON.parse(init.body as string)).toEqual({
+      projectId: 'proj-123',
+      isDesignMode: false,
+    })
+    expect(result.theme).toEqual({
+      pageWidth: 1200,
+      topbarText: 'Remote topbar',
+    })
+    expect(result.staticContent).toEqual({ greeting: 'Hello' })
+  })
+
+  it('should_return_fallback_with_defaults_when_api_fails', async () => {
+    let error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let fetchMock = vi
+      .fn()
+      .mockRejectedValue(new Error('boom')) as unknown as typeof fetch
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      themeSchema,
+      fetch: fetchMock,
+      requestContext: { url: 'https://shop.example/' },
+    })
+
+    let result = await client.loadThemeSettings()
+
+    expect(result._loadFailed).toBe(true)
+    expect(result._error).toBe('boom')
+    expect(result.theme).toEqual({
+      pageWidth: 1200,
+      topbarText: 'Default topbar',
+    })
+    expect(result.staticContent).toEqual({ greeting: 'Hello' })
+    error.mockRestore()
+  })
+
+  it('should_include_serializable_schema_and_public_env_in_design_mode', async () => {
+    let fetchMock = makeFetch({ theme: {} })
+    let designSchema = {
+      type: 'theme',
+      settings: [
+        {
+          group: 'Layout',
+          inputs: [
+            {
+              type: 'text',
+              name: 'topbarText',
+              defaultValue: 'Default',
+              condition: (data: { hidden?: boolean }) => !data.hidden,
+            },
+          ],
+        },
+      ],
+    }
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      themeSchema: designSchema,
+      env: { PUBLIC_STORE_DOMAIN: 'shop.example' },
+      fetch: fetchMock,
+      requestContext: { url: 'https://shop.example/', isDesignMode: true },
+    })
+
+    let result = await client.loadThemeSettings()
+
+    let schema = result.schema as typeof designSchema
+    let condition = schema.settings[0].inputs[0].condition
+    expect(typeof condition).toBe('string')
+    expect(result.publicEnv).toEqual({
+      PUBLIC_STORE_DOMAIN: 'shop.example',
+      PUBLIC_STOREFRONT_API_TOKEN: '',
+    })
+  })
+})
+
+// ─── 3b. trusted weaverseHost normalization ───────────────────────────
+
+describe('getWeaverseNextConfigs trusted host normalization', () => {
+  it('should_canonicalize_a_trusted_query_host_to_its_origin', () => {
+    let configs = serverEntry.getWeaverseNextConfigs({
+      searchParams: new URLSearchParams({
+        weaverseHost: 'https://studio.weaverse.io/foo?x=1',
+      }),
+    })
+
+    // Path/query from the attacker-controllable param are dropped.
+    expect(configs.weaverseHost).toBe('https://studio.weaverse.io')
+    expect(configs.weaverseApiBase).toBe('https://studio.weaverse.io')
+  })
+
+  it('should_ignore_an_untrusted_query_host', () => {
+    let configs = serverEntry.getWeaverseNextConfigs({
+      searchParams: new URLSearchParams({
+        weaverseHost: 'https://evil.example/foo',
+      }),
+    })
+
+    expect(configs.weaverseHost).toBe('https://studio.weaverse.io')
+    expect(configs.weaverseApiBase).toBe('https://api.weaverse.io')
+  })
+})
+
+// ─── 4. Server subpath exports ────────────────────────────────────────
+
+describe('@weaverse/next/server exports', () => {
+  it('should_expose_runtime_and_helper_symbols', () => {
+    expect(typeof serverEntry.createWeaverseNextServerClient).toBe('function')
+    expect(typeof serverEntry.getWeaverseNextConfigs).toBe('function')
+    expect(typeof serverEntry.normalizeNextPageUrl).toBe('function')
+    expect(typeof serverEntry.resolveRequestUrl).toBe('function')
+  })
+})

--- a/packages/next/__tests__/next-server.test.tsx
+++ b/packages/next/__tests__/next-server.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createSchema } from '../src/index'
-import * as serverEntry from '../src/server'
-import { createWeaverseNextServerClient } from '../src/server'
+import {
+  createWeaverseNextServerClient,
+  getWeaverseNextConfigs,
+  normalizeNextPageUrl,
+  resolveRequestUrl,
+} from '../src/server'
 import type {
   WeaverseNextComponentLoaderArgs,
   WeaverseNextComponentProps,
@@ -259,9 +263,9 @@ describe('createWeaverseNextServerClient loadPage', () => {
     let featured = {
       default: Hero,
       schema: createSchema({ type: 'featured', title: 'Featured' }),
-      loader: async (args: WeaverseNextComponentLoaderArgs) => {
+      loader: (args: WeaverseNextComponentLoaderArgs) => {
         received = args
-        return {}
+        return Promise.resolve({})
       },
     }
     let fetchMock = makeFetch({
@@ -461,7 +465,7 @@ describe('createWeaverseNextServerClient loadThemeSettings', () => {
 
 describe('getWeaverseNextConfigs trusted host normalization', () => {
   it('should_canonicalize_a_trusted_query_host_to_its_origin', () => {
-    let configs = serverEntry.getWeaverseNextConfigs({
+    let configs = getWeaverseNextConfigs({
       searchParams: new URLSearchParams({
         weaverseHost: 'https://studio.weaverse.io/foo?x=1',
       }),
@@ -473,7 +477,7 @@ describe('getWeaverseNextConfigs trusted host normalization', () => {
   })
 
   it('should_ignore_an_untrusted_query_host', () => {
-    let configs = serverEntry.getWeaverseNextConfigs({
+    let configs = getWeaverseNextConfigs({
       searchParams: new URLSearchParams({
         weaverseHost: 'https://evil.example/foo',
       }),
@@ -488,9 +492,9 @@ describe('getWeaverseNextConfigs trusted host normalization', () => {
 
 describe('@weaverse/next/server exports', () => {
   it('should_expose_runtime_and_helper_symbols', () => {
-    expect(typeof serverEntry.createWeaverseNextServerClient).toBe('function')
-    expect(typeof serverEntry.getWeaverseNextConfigs).toBe('function')
-    expect(typeof serverEntry.normalizeNextPageUrl).toBe('function')
-    expect(typeof serverEntry.resolveRequestUrl).toBe('function')
+    expect(typeof createWeaverseNextServerClient).toBe('function')
+    expect(typeof getWeaverseNextConfigs).toBe('function')
+    expect(typeof normalizeNextPageUrl).toBe('function')
+    expect(typeof resolveRequestUrl).toBe('function')
   })
 })

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -7,6 +7,19 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.mjs",
+      "require": "./dist/server.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public",
     "@weaverse:registry": "https://registry.npmjs.org"
@@ -30,7 +43,8 @@
   },
   "tsup": {
     "entry": [
-      "src/index.ts"
+      "src/index.ts",
+      "src/server.ts"
     ],
     "format": [
       "esm",

--- a/packages/next/src/hooks.ts
+++ b/packages/next/src/hooks.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useContext } from 'react'
+import { useContext, useSyncExternalStore } from 'react'
 import { WeaverseNextContext } from './provider'
 import type { WeaverseNextCommerceContext } from './types'
 
@@ -36,9 +36,15 @@ export function useWeaverseCommerce<T = WeaverseNextCommerceContext>(): T {
 }
 
 /**
- * Read Weaverse theme settings. Next version backed by provider root/theme
- * data (`client.themeSettings`), not the Hydrogen theme-settings store.
+ * Read live Weaverse theme settings. The Studio bridge updates the provider's
+ * external store via `updateThemeSettings`, so components re-render during live
+ * design-mode edits.
  */
 export function useThemeSettings<T = Record<string, unknown>>(): T {
-  return useWeaverseNextContext('useThemeSettings').themeSettings as T
+  let { themeSettingsStore } = useWeaverseNextContext('useThemeSettings')
+  return useSyncExternalStore(
+    themeSettingsStore.subscribe,
+    themeSettingsStore.getSnapshot,
+    themeSettingsStore.getServerSnapshot
+  ) as T
 }

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -34,6 +34,28 @@ export {
   WeaverseNextRenderer,
   type WeaverseNextRendererProps,
 } from './renderer'
+export { buildWeaverseNextRequestInfo } from './request-info'
+export {
+  bindWeaverseNextStudioRuntime,
+  createWeaverseNextRuntime,
+  WeaverseNextRuntime,
+} from './runtime'
+export {
+  WeaverseNextStudioBridge,
+  type WeaverseNextStudioBridgeProps,
+} from './studio-bridge'
+export {
+  WeaverseNextStudioConnect,
+  type WeaverseNextStudioConnectProps,
+} from './studio-connect'
+export {
+  type ResolveWeaverseNextStudioScriptSrcOptions,
+  resolveWeaverseNextStudioScriptSrc,
+} from './studio-script-src'
+export {
+  type CreateWeaverseNextThemeSettingsStoreOptions,
+  createWeaverseNextThemeSettingsStore,
+} from './theme-settings-store'
 export type {
   WeaverseCollection,
   WeaverseNextClient,
@@ -48,6 +70,10 @@ export type {
   WeaverseNextLoadPageInput,
   WeaverseNextPageData,
   WeaverseNextRequestContext,
+  WeaverseNextRequestInfo,
+  WeaverseNextRuntimeConfig,
+  WeaverseNextRuntimeInternal,
   WeaverseNextStorefront,
+  WeaverseNextThemeSettingsStore,
   WeaverseProduct,
 } from './types'

--- a/packages/next/src/provider.tsx
+++ b/packages/next/src/provider.tsx
@@ -1,7 +1,14 @@
 'use client'
 
 import { createContext, type ReactNode, useMemo } from 'react'
-import type { WeaverseNextClient, WeaverseNextCommerceContext } from './types'
+import { createWeaverseNextThemeSettingsStore } from './theme-settings-store'
+import type {
+  WeaverseNextClient,
+  WeaverseNextCommerceContext,
+  WeaverseNextThemeSettingsStore,
+} from './types'
+
+const EMPTY_THEME_SETTINGS: Record<string, unknown> = {}
 
 /**
  * Value carried by {@link WeaverseNextContext}. Holds the explicit data
@@ -14,6 +21,7 @@ export interface WeaverseNextContextValue {
   pageData?: unknown
   rootData?: unknown
   themeSettings: Record<string, unknown>
+  themeSettingsStore: WeaverseNextThemeSettingsStore
 }
 
 /**
@@ -57,15 +65,27 @@ export interface WeaverseNextProviderProps {
 export function WeaverseNextProvider(props: WeaverseNextProviderProps) {
   let { children, client, rootData, pageData, commerce, themeSettings } = props
 
+  let themeSettingsValue =
+    themeSettings ?? client?.themeSettings ?? EMPTY_THEME_SETTINGS
+  let themeSettingsStore = useMemo(
+    () =>
+      createWeaverseNextThemeSettingsStore({
+        schema: client?.themeSchema,
+        settings: themeSettingsValue,
+      }),
+    [client?.themeSchema, themeSettingsValue]
+  )
+
   let value = useMemo<WeaverseNextContextValue>(
     () => ({
       client,
       rootData,
       pageData,
       commerce: commerce ?? client?.commerce,
-      themeSettings: themeSettings ?? client?.themeSettings ?? {},
+      themeSettings: themeSettingsStore.getSnapshot(),
+      themeSettingsStore,
     }),
-    [client, rootData, pageData, commerce, themeSettings]
+    [client, rootData, pageData, commerce, themeSettingsStore]
   )
 
   return (

--- a/packages/next/src/renderer.tsx
+++ b/packages/next/src/renderer.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { Weaverse, WeaverseRoot } from '@weaverse/react'
+import { WeaverseRoot } from '@weaverse/react'
 import { memo, useContext, useMemo } from 'react'
 import { WeaverseNextContext } from './provider'
+import { createWeaverseNextRuntime } from './runtime'
+import { WeaverseNextStudioBridge } from './studio-bridge'
 import type {
   WeaverseNextClient,
   WeaverseNextLoaderData,
@@ -59,23 +61,22 @@ export const WeaverseNextRenderer = memo(function WeaverseNextRendererComponent(
       return null
     }
 
-    let instance = new Weaverse({
-      projectId: client?.projectId || page.id || 'weaverse-next',
-      data: page,
+    return createWeaverseNextRuntime({
+      client,
+      data: { ...(data as WeaverseNextLoaderData), page },
+      dataContext,
+      themeSettingsStore: context?.themeSettingsStore,
     })
-    instance.dataContext = dataContext
-    instance.isDesignMode = client?.requestContext?.isDesignMode ?? false
-    return instance
-  }, [
-    client?.projectId,
-    client?.requestContext?.isDesignMode,
-    page,
-    dataContext,
-  ])
+  }, [client, page, data, dataContext, context?.themeSettingsStore])
 
   if (!weaverse) {
     return null
   }
 
-  return <WeaverseRoot context={weaverse} />
+  return (
+    <>
+      <WeaverseRoot context={weaverse} />
+      <WeaverseNextStudioBridge runtime={weaverse} />
+    </>
+  )
 })

--- a/packages/next/src/request-info.ts
+++ b/packages/next/src/request-info.ts
@@ -1,0 +1,75 @@
+import type {
+  WeaverseNextRequestContext,
+  WeaverseNextRequestInfo,
+} from './types'
+
+function toUrl(value: string | URL): URL {
+  return typeof value === 'string' ? new URL(value, 'http://localhost') : value
+}
+
+function getSearchParamsFromContext(
+  context?: WeaverseNextRequestContext
+): URLSearchParams {
+  if (context?.searchParams) {
+    return new URLSearchParams(context.searchParams)
+  }
+
+  if (context?.url) {
+    let url = toUrl(context.url)
+    return new URLSearchParams(url.searchParams)
+  }
+
+  return new URLSearchParams()
+}
+
+function getPathnameFromContext(context?: WeaverseNextRequestContext): string {
+  if (context?.pathname) {
+    return context.pathname
+  }
+
+  if (context?.url) {
+    let url = toUrl(context.url)
+    return url.pathname || '/'
+  }
+
+  return '/'
+}
+
+function coerceQueryValue(value: string): string | boolean {
+  if (value === 'true') {
+    return true
+  }
+  if (value === 'false') {
+    return false
+  }
+  return value
+}
+
+function toQueryRecord(
+  searchParams: URLSearchParams
+): Record<string, string | boolean> {
+  let queries: Record<string, string | boolean> = {}
+  for (let [key, value] of searchParams.entries()) {
+    queries[key] = coerceQueryValue(value)
+  }
+  return queries
+}
+
+/**
+ * Build the Hydrogen-like request info shape consumed by the Studio bridge.
+ * Duplicate query keys keep the last value, matching `URLSearchParams` iteration
+ * assignment and Hydrogen's practical query-object behavior.
+ */
+export function buildWeaverseNextRequestInfo(
+  context?: WeaverseNextRequestContext
+): WeaverseNextRequestInfo {
+  let searchParams = getSearchParamsFromContext(context)
+  let search = searchParams.toString()
+
+  return {
+    pathname: getPathnameFromContext(context),
+    search: search ? `?${search}` : '',
+    queries: toQueryRecord(searchParams),
+    ...(context?.i18n ? { i18n: context.i18n } : {}),
+  }
+}

--- a/packages/next/src/runtime.ts
+++ b/packages/next/src/runtime.ts
@@ -1,0 +1,240 @@
+import { Weaverse } from '@weaverse/react'
+import { ensureNextItemConstructor } from './item'
+import { buildWeaverseNextRequestInfo } from './request-info'
+import { createWeaverseNextThemeSettingsStore } from './theme-settings-store'
+import type {
+  WeaverseNextClient,
+  WeaverseNextLoaderData,
+  WeaverseNextPageData,
+  WeaverseNextRequestInfo,
+  WeaverseNextRuntimeConfig,
+  WeaverseNextRuntimeInternal,
+} from './types'
+
+declare global {
+  interface Window {
+    __weaverse?: WeaverseNextRuntime
+    __weaverses?: Record<string, WeaverseNextRuntime>
+  }
+}
+
+type StudioBoundRuntime = WeaverseNextRuntime & {
+  __weaverseNextStudioBound?: boolean
+  __weaverseNextRequestKey?: string
+}
+
+function getRuntimeWindow(): Window | undefined {
+  return typeof window === 'undefined' ? undefined : window
+}
+
+function getRenderablePage(
+  data: WeaverseNextLoaderData
+): WeaverseNextPageData & { rootId: string } {
+  let page = data.page
+  let rootId =
+    page.rootId ??
+    page.items.find((item) => item.type === 'main')?.id ??
+    page.items[0]?.id ??
+    page.id
+  return { ...page, rootId }
+}
+
+function getConfigString(
+  configs: Record<string, unknown> | undefined,
+  key: string
+): string | undefined {
+  let value = configs?.[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function getRecordString(
+  record: Record<string, unknown> | undefined,
+  key: string
+): string | undefined {
+  let value = record?.[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function resolveProjectId(
+  client: WeaverseNextClient | undefined,
+  data: WeaverseNextLoaderData,
+  fallback: string
+): string {
+  let projectId = client?.projectId
+  if (projectId) {
+    return projectId
+  }
+
+  let configProjectId = getConfigString(data.configs, 'projectId')
+  if (configProjectId) {
+    return configProjectId
+  }
+
+  return getRecordString(data.project, 'id') ?? fallback
+}
+
+function resolveDataContext(config: WeaverseNextRuntimeConfig) {
+  if (config.dataContext) {
+    return config.dataContext
+  }
+  if (config.client?.dataContext) {
+    return config.client.dataContext
+  }
+  return {}
+}
+
+function getRuntimeKey(pageId: string, requestInfo: WeaverseNextRequestInfo) {
+  return `${pageId}:${requestInfo.pathname}:${requestInfo.search}`
+}
+
+function registerRuntime(runtime: WeaverseNextRuntime) {
+  let runtimeWindow = getRuntimeWindow()
+  if (!runtimeWindow) {
+    return
+  }
+
+  runtimeWindow.__weaverses ??= {}
+  runtimeWindow.__weaverses[runtime.pageId] = runtime
+  runtimeWindow.__weaverse = runtime
+}
+
+export class WeaverseNextRuntime extends Weaverse {
+  pageId: string
+  internal: WeaverseNextRuntimeInternal
+  requestInfo: WeaverseNextRequestInfo
+  isPreviewMode: boolean
+  isRevisionPreview: boolean
+  sectionType?: string
+  translationMap: Record<string, unknown> = {}
+  translationLocale = ''
+  translationLanguageId = ''
+
+  constructor(config: WeaverseNextRuntimeConfig) {
+    let { client, data } = config
+    let page = getRenderablePage(data)
+    let configs = data.configs
+    let requestContext = client?.requestContext
+    let projectId = resolveProjectId(client, data, page.id)
+
+    ensureNextItemConstructor()
+    super({
+      projectId,
+      data: page,
+      isDesignMode: requestContext?.isDesignMode ?? false,
+      weaverseHost: getConfigString(configs, 'weaverseHost'),
+      weaverseVersion: getConfigString(configs, 'weaverseVersion'),
+    })
+
+    this.pageId = page.id
+    this.dataContext = resolveDataContext(config)
+    this.requestInfo = buildWeaverseNextRequestInfo(requestContext)
+    this.isDesignMode = requestContext?.isDesignMode ?? false
+    this.isPreviewMode = requestContext?.isPreviewMode ?? false
+    this.isRevisionPreview = requestContext?.isRevisionPreview ?? false
+    this.sectionType = requestContext?.sectionType
+    this.weaverseHost =
+      getConfigString(configs, 'weaverseHost') ?? this.weaverseHost
+    this.weaverseVersion =
+      getConfigString(configs, 'weaverseVersion') ?? this.weaverseVersion
+
+    this.internal = {
+      navigate: config.navigate,
+      pageAssignment: data.pageAssignment,
+      project: data.project,
+      revalidate: config.revalidate,
+      themeSettingsStore:
+        config.themeSettingsStore ??
+        createWeaverseNextThemeSettingsStore({
+          schema: client?.themeSchema,
+          settings: client?.themeSettings,
+        }),
+    }
+  }
+
+  extractTranslationSidecar = () => undefined
+  setTranslationSidecar = (
+    map: Record<string, unknown> = {},
+    locale = '',
+    languageId = ''
+  ) => {
+    this.translationMap = map
+    this.translationLocale = locale
+    this.translationLanguageId = languageId
+  }
+  updateTranslation = () => undefined
+  getTranslationChanges = () => undefined
+}
+
+export function createWeaverseNextRuntime(
+  config: WeaverseNextRuntimeConfig
+): WeaverseNextRuntime {
+  let requestInfo = buildWeaverseNextRequestInfo(config.client?.requestContext)
+  let page = getRenderablePage(config.data)
+  let runtimeWindow = getRuntimeWindow()
+  let existing = runtimeWindow?.__weaverses?.[page.id] as
+    | StudioBoundRuntime
+    | undefined
+  let requestKey = getRuntimeKey(page.id, requestInfo)
+
+  if (existing?.__weaverseNextRequestKey === requestKey) {
+    existing.setProjectData(page)
+    existing.dataContext = resolveDataContext(config)
+    existing.requestInfo = requestInfo
+    existing.projectId = resolveProjectId(config.client, config.data, page.id)
+    existing.isDesignMode = config.client?.requestContext?.isDesignMode ?? false
+    existing.isPreviewMode =
+      config.client?.requestContext?.isPreviewMode ?? false
+    existing.isRevisionPreview =
+      config.client?.requestContext?.isRevisionPreview ?? false
+    existing.sectionType = config.client?.requestContext?.sectionType
+    existing.weaverseHost =
+      getConfigString(config.data.configs, 'weaverseHost') ??
+      existing.weaverseHost
+    existing.weaverseVersion =
+      getConfigString(config.data.configs, 'weaverseVersion') ??
+      existing.weaverseVersion
+    existing.internal.pageAssignment = config.data.pageAssignment
+    existing.internal.project = config.data.project
+    if (config.navigate) {
+      existing.internal.navigate = config.navigate
+    }
+    if (config.revalidate) {
+      existing.internal.revalidate = config.revalidate
+    }
+    if (config.themeSettingsStore) {
+      existing.internal.themeSettingsStore = config.themeSettingsStore
+    }
+    registerRuntime(existing)
+    return existing
+  }
+
+  let runtime = new WeaverseNextRuntime(config) as StudioBoundRuntime
+  runtime.__weaverseNextRequestKey = requestKey
+  registerRuntime(runtime)
+  return runtime
+}
+
+export function bindWeaverseNextStudioRuntime(runtime: WeaverseNextRuntime) {
+  if (!runtime.isDesignMode) {
+    return false
+  }
+
+  let studio = getRuntimeWindow()?.weaverseStudio
+  if (!studio) {
+    return false
+  }
+
+  let boundRuntime = runtime as StudioBoundRuntime
+  if (!boundRuntime.__weaverseNextStudioBound) {
+    studio.init?.(runtime)
+    boundRuntime.__weaverseNextStudioBound = true
+    return true
+  }
+
+  studio.refreshStudio?.({
+    data: runtime.data,
+    pageId: runtime.pageId,
+    requestInfo: runtime.requestInfo,
+  })
+  return true
+}

--- a/packages/next/src/runtime.ts
+++ b/packages/next/src/runtime.ts
@@ -132,10 +132,6 @@ export class WeaverseNextRuntime extends Weaverse {
     this.isPreviewMode = requestContext?.isPreviewMode ?? false
     this.isRevisionPreview = requestContext?.isRevisionPreview ?? false
     this.sectionType = requestContext?.sectionType
-    this.weaverseHost =
-      getConfigString(configs, 'weaverseHost') ?? this.weaverseHost
-    this.weaverseVersion =
-      getConfigString(configs, 'weaverseVersion') ?? this.weaverseVersion
 
     this.internal = {
       navigate: config.navigate,
@@ -177,11 +173,19 @@ export function createWeaverseNextRuntime(
   let requestKey = getRuntimeKey(page.id, requestInfo)
 
   if (existing?.__weaverseNextRequestKey === requestKey) {
-    existing.setProjectData(page)
+    let nextIsDesignMode = config.client?.requestContext?.isDesignMode ?? false
+    // In design mode the live Studio runtime owns the page tree, including
+    // unsaved drafts. Reapplying loader `page` data here would clobber those
+    // edits, so leave the project data untouched and let
+    // `bindWeaverseNextStudioRuntime` push the latest state via `refreshStudio`.
+    // Published / preview reuse has no draft state, so fresh data still wins.
+    if (!(existing.isDesignMode || nextIsDesignMode)) {
+      existing.setProjectData(page)
+    }
     existing.dataContext = resolveDataContext(config)
     existing.requestInfo = requestInfo
     existing.projectId = resolveProjectId(config.client, config.data, page.id)
-    existing.isDesignMode = config.client?.requestContext?.isDesignMode ?? false
+    existing.isDesignMode = nextIsDesignMode
     existing.isPreviewMode =
       config.client?.requestContext?.isPreviewMode ?? false
     existing.isRevisionPreview =

--- a/packages/next/src/server.ts
+++ b/packages/next/src/server.ts
@@ -1,0 +1,26 @@
+// Server entrypoint for `@weaverse/next/server`.
+//
+// Exposes the server-side Weaverse client that performs the real Weaverse
+// public API fetch (page + theme settings) from Next.js App Router routes and
+// server components — the equivalent of Hydrogen's
+// `context.weaverse.loadPage(...)` pattern. Kept on a dedicated subpath so the
+// root `@weaverse/next` entry stays free of server-only fetch assumptions.
+
+export { getWeaverseNextConfigs } from './server/configs'
+export {
+  normalizeNextPageUrl,
+  resolveRequestUrl,
+} from './server/normalize-page-url'
+export { createWeaverseNextServerClient } from './server/server-client'
+export type {
+  WeaverseNextBaseConfigs,
+  WeaverseNextCacheConfig,
+  WeaverseNextConfigs,
+  WeaverseNextFetchOptions,
+  WeaverseNextProjectId,
+  WeaverseNextServerClient,
+  WeaverseNextServerClientConfig,
+  WeaverseNextServerLoadPageInput,
+  WeaverseNextThemeSettingsOptions,
+  WeaverseNextThemeSettingsResponse,
+} from './types'

--- a/packages/next/src/server/configs.ts
+++ b/packages/next/src/server/configs.ts
@@ -1,0 +1,177 @@
+import type {
+  WeaverseNextBaseConfigs,
+  WeaverseNextRequestContext,
+} from '../types'
+
+const DEFAULT_WEAVERSE_HOST = 'https://studio.weaverse.io'
+const DEFAULT_WEAVERSE_API_BASE = 'https://api.weaverse.io'
+
+/**
+ * Weaverse-controlled apex domains the Studio bridge / data API may be served
+ * from (matched on the host itself and any subdomain). Kept in sync with
+ * Hydrogen's `isTrustedStudioHost`.
+ */
+const TRUSTED_STUDIO_DOMAINS = ['weaverse.io', 'weaverse.dev']
+
+/**
+ * Whether `host` is an origin we trust to resolve page/theme data. The
+ * `weaverseHost` query param is attacker-controllable, so a crafted
+ * `?weaverseHost=` must be rejected before it can point server-side fetches at
+ * an arbitrary origin (SSRF). Only `weaverse.io`/`weaverse.dev` and subdomains
+ * over https are trusted.
+ */
+function isTrustedStudioHost(host: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(host)
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'https:') {
+    return false
+  }
+  let { hostname } = parsed
+  return TRUSTED_STUDIO_DOMAINS.some(
+    (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
+  )
+}
+
+function toUrl(value: string | URL): URL | null {
+  try {
+    return typeof value === 'string'
+      ? new URL(value, 'http://localhost')
+      : value
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extract the request search params from the explicit Next request context.
+ * Prefers `searchParams`, falls back to parsing `url`.
+ */
+export function getContextSearchParams(
+  context?: WeaverseNextRequestContext
+): URLSearchParams {
+  if (context?.searchParams) {
+    return new URLSearchParams(context.searchParams)
+  }
+  if (context?.url) {
+    let url = toUrl(context.url)
+    if (url) {
+      return new URLSearchParams(url.searchParams)
+    }
+  }
+  return new URLSearchParams()
+}
+
+/**
+ * Last value of a (possibly duplicated) query key. Matches Hydrogen's
+ * `getRequestQueries`, which assigns while iterating and so keeps the last
+ * occurrence — Studio appends its own control params, so a stale earlier value
+ * must not win.
+ */
+function lastParam(
+  searchParams: URLSearchParams,
+  key: string
+): string | undefined {
+  let values = searchParams.getAll(key)
+  return values.length ? values.at(-1) : undefined
+}
+
+function coerceBool(value: string | undefined): boolean {
+  return value === 'true'
+}
+
+function readEnv(
+  env: Record<string, string | undefined> | undefined,
+  key: string
+): string | undefined {
+  let fromConfig = env?.[key]
+  if (fromConfig !== undefined) {
+    return fromConfig
+  }
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env[key]
+  }
+  return
+}
+
+export interface ResolveConfigsOptions {
+  env?: Record<string, string | undefined>
+  weaverseApiBase?: string
+  weaverseHost?: string
+  weaverseVersion?: string
+}
+
+/**
+ * Derive Weaverse configs from the request context and env, close to Hydrogen's
+ * `getWeaverseConfigs`. Resolves the trusted host, public API base, design /
+ * preview / revision flags, and public env — but never resolves the final
+ * `projectId` (that priority chain, which may call an async resolver, lives in
+ * the server client). Query/env projectId candidates are returned for the
+ * client to combine with function/string inputs.
+ */
+export function getWeaverseNextConfigs(
+  context?: WeaverseNextRequestContext,
+  options: ResolveConfigsOptions = {}
+): WeaverseNextBaseConfigs {
+  let searchParams = getContextSearchParams(context)
+  let { env } = options
+
+  let queryHost = lastParam(searchParams, 'weaverseHost')
+  // A trusted query host is canonicalized to its origin before use, so a crafted
+  // `?weaverseHost=https://studio.weaverse.io/evil?x=1` can only ever resolve to
+  // `https://studio.weaverse.io` — never carrying an attacker path/query into the
+  // server-side API base.
+  let trustedUrlHost =
+    queryHost && isTrustedStudioHost(queryHost) ? new URL(queryHost).origin : ''
+
+  let configuredHost =
+    options.weaverseHost || readEnv(env, 'WEAVERSE_HOST') || ''
+  let weaverseHost = trustedUrlHost || configuredHost || DEFAULT_WEAVERSE_HOST
+
+  // Public data reads default to the edge proxy, but an explicit custom host
+  // (staging/self-hosted Weaverse) must stay the API base so those deployments
+  // don't fetch page/config data from the production proxy.
+  let weaverseApiBase =
+    trustedUrlHost ||
+    options.weaverseApiBase ||
+    readEnv(env, 'WEAVERSE_PUBLIC_API_BASE') ||
+    (configuredHost && configuredHost !== DEFAULT_WEAVERSE_HOST
+      ? configuredHost
+      : DEFAULT_WEAVERSE_API_BASE)
+
+  let isRevisionPreview =
+    context?.isRevisionPreview ?? searchParams.has('__revisionId')
+  let isDesignMode =
+    context?.isDesignMode ?? coerceBool(lastParam(searchParams, 'isDesignMode'))
+  let isPreviewMode =
+    context?.isPreviewMode ??
+    coerceBool(lastParam(searchParams, 'isPreviewMode'))
+
+  return {
+    queryProjectId: lastParam(searchParams, 'weaverseProjectId') || '',
+    envProjectId: readEnv(env, 'WEAVERSE_PROJECT_ID') || '',
+    weaverseHost,
+    weaverseApiBase,
+    weaverseApiKey:
+      lastParam(searchParams, 'weaverseApiKey') ||
+      readEnv(env, 'WEAVERSE_API_KEY') ||
+      '',
+    weaverseVersion:
+      lastParam(searchParams, 'weaverseVersion') ||
+      options.weaverseVersion ||
+      '',
+    isDesignMode,
+    isPreviewMode,
+    isRevisionPreview,
+    sectionType:
+      context?.sectionType || lastParam(searchParams, 'sectionType') || '',
+    publicEnv: {
+      PUBLIC_STORE_DOMAIN: readEnv(env, 'PUBLIC_STORE_DOMAIN') || '',
+      PUBLIC_STOREFRONT_API_TOKEN:
+        readEnv(env, 'PUBLIC_STOREFRONT_API_TOKEN') || '',
+    },
+  }
+}

--- a/packages/next/src/server/normalize-page-url.ts
+++ b/packages/next/src/server/normalize-page-url.ts
@@ -1,0 +1,62 @@
+import type { WeaverseNextRequestContext } from '../types'
+
+// Query params that influence Weaverse page resolution on the Builder:
+// revision previews, design-mode flags, and `weaverse*` control params
+// (host, version, project id). Everything else — utm_*, fbclid, gclid,
+// storefront filters — is irrelevant to which page the Builder returns and
+// would otherwise fragment any fetch cache keyed on the request body.
+const KEPT_PARAM_RE = /^(?:__revisionId|isDesignMode|weaverse)/
+const DATA_SUFFIX = '.data'
+
+/**
+ * Normalize the storefront URL sent in the Builder page API request body.
+ *
+ * The Builder reads only the pathname (locale/type/handle fallback) and the
+ * Weaverse/Studio control params from this URL, so keep exactly those and drop
+ * tracking params. Params are sorted for a stable, cache-friendly string.
+ *
+ * Ported from `@weaverse/hydrogen`'s `normalizePageUrl`, but tolerant of a
+ * relative URL (Next route handlers may only know the pathname).
+ */
+export function normalizeNextPageUrl(url: string): string {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    try {
+      parsed = new URL(url, 'http://localhost')
+    } catch {
+      return url
+    }
+  }
+
+  let kept = [...parsed.searchParams].filter(([key]) => KEPT_PARAM_RE.test(key))
+  kept.sort(([a], [b]) => a.localeCompare(b))
+  let search = new URLSearchParams(kept).toString()
+
+  let { pathname } = parsed
+  if (pathname.endsWith(DATA_SUFFIX)) {
+    pathname = pathname.slice(0, -DATA_SUFFIX.length)
+  }
+  return `${parsed.origin}${pathname}${search ? `?${search}` : ''}`
+}
+
+/**
+ * Build an absolute-ish request URL string from the explicit request context,
+ * preferring `url`, then `pathname` + `searchParams`. Used as the input to
+ * {@link normalizeNextPageUrl}.
+ */
+export function resolveRequestUrl(
+  context?: WeaverseNextRequestContext
+): string {
+  if (context?.url) {
+    return typeof context.url === 'string'
+      ? context.url
+      : context.url.toString()
+  }
+  let pathname = context?.pathname || '/'
+  let search = context?.searchParams
+    ? new URLSearchParams(context.searchParams).toString()
+    : ''
+  return `http://localhost${pathname}${search ? `?${search}` : ''}`
+}

--- a/packages/next/src/server/server-client.ts
+++ b/packages/next/src/server/server-client.ts
@@ -335,7 +335,7 @@ class NextServerClient implements WeaverseNextServerClient {
     return effectiveProjectId
   }
 
-  private async _fetchPagePayload(
+  private _fetchPagePayload(
     projectId: string,
     params: Record<string, unknown>,
     cache?: WeaverseNextCacheConfig

--- a/packages/next/src/server/server-client.ts
+++ b/packages/next/src/server/server-client.ts
@@ -1,6 +1,5 @@
 import type { SchemaType } from '@weaverse/schema'
 import { runWeaverseComponentLoaders } from '../loader'
-import { registerWeaverseNextComponents } from '../registry'
 import { buildWeaverseNextRequestInfo } from '../request-info'
 import type {
   WeaverseNextBaseConfigs,
@@ -86,8 +85,15 @@ class NextServerClient implements WeaverseNextServerClient {
   private _resolvedProjectId?: string
 
   constructor(config: WeaverseNextServerClientConfig) {
+    // Server client keeps the component definitions for server-side loaders
+    // (`runWeaverseComponentLoaders`) and preview-data generation, but it
+    // intentionally does NOT call `registerWeaverseNextComponents`. Registering
+    // pulls in `../registry` → `@weaverse/react`, which evaluates
+    // `React.createContext()` at module load — invalid in the RSC/server graph
+    // and the cause of `(0 , x.createContext) is not a function`. The client
+    // wrapper/renderer (root `@weaverse/next` client entry) registers the real
+    // render components instead, keeping `@weaverse/next/server` React-free.
     this.components = config.components
-    registerWeaverseNextComponents(this.components)
     this.commerce = config.commerce
     this.requestContext = config.requestContext
     this.themeSchema = config.themeSchema

--- a/packages/next/src/server/server-client.ts
+++ b/packages/next/src/server/server-client.ts
@@ -1,0 +1,547 @@
+import type { SchemaType } from '@weaverse/schema'
+import { runWeaverseComponentLoaders } from '../loader'
+import { registerWeaverseNextComponents } from '../registry'
+import { buildWeaverseNextRequestInfo } from '../request-info'
+import type {
+  WeaverseNextBaseConfigs,
+  WeaverseNextCommerceContext,
+  WeaverseNextComponent,
+  WeaverseNextComponentData,
+  WeaverseNextConfigs,
+  WeaverseNextFetchOptions,
+  WeaverseNextLoaderData,
+  WeaverseNextLoadPageInput,
+  WeaverseNextPageData,
+  WeaverseNextProjectId,
+  WeaverseNextRequestContext,
+  WeaverseNextServerClient,
+  WeaverseNextServerClientConfig,
+  WeaverseNextServerLoadPageInput,
+  WeaverseNextStorefront,
+  WeaverseNextThemeSettingsOptions,
+  WeaverseNextThemeSettingsResponse,
+} from '../types'
+import { generateDataFromSchema } from '../utils'
+import { getContextSearchParams, getWeaverseNextConfigs } from './configs'
+import { normalizeNextPageUrl, resolveRequestUrl } from './normalize-page-url'
+
+const DEFAULT_FETCH_TIMEOUT_MS = 10_000
+
+const JSON_HEADERS = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+  'Accept-Encoding': 'gzip, deflate, br',
+} as const
+
+/** Next's `fetch` reads `next: { revalidate, tags }` off the request init. */
+type NextRequestInit = RequestInit & {
+  next?: { revalidate?: number | false; tags?: string[] }
+}
+
+type LooseThemeSchema = {
+  i18n?: { staticContent?: Record<string, unknown> }
+  inspector?: unknown[]
+  settings?: {
+    inputs?: { condition?: unknown }[]
+    [key: string]: unknown
+  }[]
+}
+
+function asThemeSchema(schema: unknown): LooseThemeSchema | undefined {
+  return schema && typeof schema === 'object'
+    ? (schema as LooseThemeSchema)
+    : undefined
+}
+
+function generateUuid(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return `id-${Math.random().toString(36).slice(2)}`
+}
+
+/**
+ * Server-side Weaverse client for Next.js. Performs the real Weaverse public
+ * API fetch (page + theme settings) instead of delegating to injected fetchers,
+ * closing the gap with Hydrogen's `context.weaverse.loadPage(...)`.
+ */
+class NextServerClient implements WeaverseNextServerClient {
+  components: WeaverseNextComponent[]
+  commerce?: WeaverseNextCommerceContext
+  requestContext?: WeaverseNextRequestContext
+  themeSchema?: unknown
+  themeSettings: Record<string, unknown>
+  data: WeaverseNextLoaderData | null = null
+  dataContext: Record<string, unknown> = {}
+  configs: WeaverseNextConfigs
+
+  private readonly _projectIdInput?: WeaverseNextProjectId
+  private readonly _baseConfigs: WeaverseNextBaseConfigs
+  private readonly _fetch: typeof fetch
+  private readonly _cache?: WeaverseNextServerClientConfig['cache']
+  private readonly _fetchTimeoutMs: number
+  private _resolvedProjectId?: string
+
+  constructor(config: WeaverseNextServerClientConfig) {
+    this.components = config.components
+    registerWeaverseNextComponents(this.components)
+    this.commerce = config.commerce
+    this.requestContext = config.requestContext
+    this.themeSchema = config.themeSchema
+    // Seed schema defaults before merchant overrides, mirroring the root client.
+    this.themeSettings = {
+      ...generateDataFromSchema(config.themeSchema as SchemaType | undefined),
+      ...config.themeSettings,
+    }
+    this._projectIdInput = config.projectId
+    this._fetch = config.fetch ?? globalThis.fetch
+    this._cache = config.cache
+    this._fetchTimeoutMs = config.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS
+
+    this._baseConfigs = getWeaverseNextConfigs(config.requestContext, {
+      env: config.env,
+      weaverseHost: config.weaverseHost,
+      weaverseApiBase: config.weaverseApiBase,
+      weaverseVersion: config.weaverseVersion,
+    })
+
+    // Synchronous best-effort projectId (query → string → env). A function
+    // resolver is awaited lazily in `resolveProjectId`, so `projectId` reflects
+    // its result after the first `loadPage`/`loadThemeSettings`/`resolveProjectId`.
+    this.configs = this._buildPublicConfigs(
+      this._baseConfigs.queryProjectId ||
+        (typeof this._projectIdInput === 'string'
+          ? this._projectIdInput.trim()
+          : '') ||
+        this._baseConfigs.envProjectId
+    )
+  }
+
+  get projectId(): string {
+    return this.configs.projectId
+  }
+
+  /** Compatibility alias so loaders can call `weaverse.storefront.query(...)`. */
+  get storefront(): WeaverseNextStorefront | undefined {
+    return this.commerce?.storefront
+  }
+
+  private _buildPublicConfigs(projectId: string): WeaverseNextConfigs {
+    let base = this._baseConfigs
+    return {
+      projectId,
+      weaverseHost: base.weaverseHost,
+      weaverseApiBase: base.weaverseApiBase,
+      weaversePublicApiBase: base.weaverseApiBase,
+      weaverseVersion: base.weaverseVersion,
+      isDesignMode: base.isDesignMode,
+      isPreviewMode: base.isPreviewMode,
+      isRevisionPreview: base.isRevisionPreview,
+      sectionType: base.sectionType,
+      publicEnv: base.publicEnv,
+    }
+  }
+
+  resolveProjectId = async (): Promise<string> => {
+    if (this._resolvedProjectId !== undefined) {
+      return this._resolvedProjectId
+    }
+
+    // Priority: query param → function → string → env (matches Hydrogen).
+    let resolved = this._baseConfigs.queryProjectId
+    if (!resolved && typeof this._projectIdInput === 'function') {
+      try {
+        let value = await this._projectIdInput(this.requestContext)
+        if (typeof value === 'string' && value.trim()) {
+          resolved = value.trim()
+        }
+      } catch (error) {
+        console.warn(
+          '[WeaverseNextServerClient] projectId resolver threw, falling back.',
+          error
+        )
+      }
+    }
+    if (!resolved && typeof this._projectIdInput === 'string') {
+      resolved = this._projectIdInput.trim()
+    }
+    if (!resolved) {
+      resolved = this._baseConfigs.envProjectId
+    }
+
+    this._resolvedProjectId = resolved
+    this.configs = this._buildPublicConfigs(resolved)
+    return resolved
+  }
+
+  fetchWithCache = async <T = unknown>(
+    url: string,
+    options: WeaverseNextFetchOptions = {}
+  ): Promise<T> => {
+    let { revalidate, tags, ...init } = options
+    let requestInit: NextRequestInit = { ...init }
+
+    let { isDesignMode, isRevisionPreview } = this._baseConfigs
+    if (isDesignMode || isRevisionPreview) {
+      // Design / revision data must never be served stale.
+      requestInit.cache = 'no-store'
+    } else if (requestInit.cache === undefined) {
+      let effectiveRevalidate = revalidate ?? this._cache?.revalidate
+      let effectiveTags = tags ?? this._cache?.tags
+      if (effectiveRevalidate !== undefined || effectiveTags?.length) {
+        requestInit.next = {
+          ...(effectiveRevalidate === undefined
+            ? {}
+            : { revalidate: effectiveRevalidate }),
+          ...(effectiveTags?.length ? { tags: effectiveTags } : {}),
+        }
+      }
+    }
+
+    let controller = new AbortController()
+    let timeoutId = setTimeout(() => controller.abort(), this._fetchTimeoutMs)
+    try {
+      let response = await this._fetch(url, {
+        ...requestInit,
+        signal: requestInit.signal ?? controller.signal,
+      })
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      }
+      return (await response.json()) as T
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  }
+
+  private _generateFallbackPage(message: string): WeaverseNextPageData {
+    let rootId = generateUuid()
+    return {
+      id: `fallback_page_${rootId}`,
+      rootId,
+      name: 'Default Page',
+      items: [
+        {
+          type: 'main',
+          id: rootId,
+          data: { dangerouslySetInnerHTML: { __html: message } },
+        },
+      ],
+    }
+  }
+
+  /**
+   * Recursively materialize a section preset (and its preset children) into a
+   * flat list of page items, returning the new item id. Ported from Hydrogen's
+   * `recursivelyAddDataItem`. Returns `undefined` when the type isn't registered.
+   */
+  private _buildPreviewItems(
+    type: string,
+    items: WeaverseNextComponentData[],
+    initData: Record<string, unknown> = {}
+  ): string | undefined {
+    let component = this.components.find((c) => c.schema?.type === type)
+    if (!component) {
+      return
+    }
+    let { children, ...data } = (component.schema?.presets ?? {}) as {
+      children?: { type: string; [key: string]: unknown }[]
+      [key: string]: unknown
+    }
+    let childIds: { id: string }[] = []
+    if (children) {
+      for (let child of children) {
+        let { type: childType, children: _children, ...childData } = child
+        let childId = this._buildPreviewItems(childType, items, childData)
+        if (childId) {
+          childIds.push({ id: childId })
+        }
+      }
+    }
+    let id = generateUuid()
+    items.push({ id, type, data: { ...data, ...initData }, children: childIds })
+    return id
+  }
+
+  /**
+   * Synthetic loader data for Studio "section preview" mode. Mirrors Hydrogen's
+   * `getPreviewData`: it builds a single-section page from the requested
+   * `sectionType`'s presets without hitting `/api/public/project`, so preview
+   * works even without a resolved `projectId`.
+   */
+  private _generatePreviewData(projectId: string): WeaverseNextLoaderData {
+    let { sectionType, weaverseHost } = this._baseConfigs
+    let items: WeaverseNextComponentData[] = []
+    let sectionId = sectionType
+      ? this._buildPreviewItems(sectionType, items)
+      : undefined
+
+    let configs = {
+      ...this._buildPublicConfigs(projectId),
+      isPreviewMode: true,
+      weaverseHost,
+      requestInfo: buildWeaverseNextRequestInfo(this.requestContext),
+    }
+
+    return {
+      project: {
+        id: projectId,
+        weaverseShopId: 'shop-id',
+        name: 'Section Preview',
+      },
+      configs,
+      page: {
+        id: 'weaverse-preview-page',
+        name: 'Preview section',
+        rootId: '1',
+        items: [
+          {
+            id: '1',
+            type: 'main',
+            data: {},
+            children: sectionId ? [{ id: sectionId }] : [],
+          },
+          ...items,
+        ],
+      },
+    }
+  }
+
+  loadPage = async (
+    input: WeaverseNextLoadPageInput = {}
+  ): Promise<WeaverseNextLoaderData | null> => {
+    try {
+      let {
+        cache,
+        projectId: routeProjectId,
+        ...rest
+      } = input as WeaverseNextServerLoadPageInput
+      let effectiveProjectId =
+        (typeof routeProjectId === 'string' && routeProjectId.trim()) ||
+        (await this.resolveProjectId())
+
+      // Propagate a route-level projectId override to the public configs *before*
+      // running component loaders and returning, so `client.projectId`,
+      // `args.weaverse.projectId`, and the runtime all observe the override.
+      if (effectiveProjectId) {
+        this.configs = this._buildPublicConfigs(effectiveProjectId)
+      }
+
+      // Studio "section preview" mode renders a single section from its presets
+      // without a real page fetch — and must work even without a projectId.
+      if (this._baseConfigs.isPreviewMode) {
+        let previewData = this._generatePreviewData(effectiveProjectId || 'x')
+        this.data = previewData
+        return previewData
+      }
+
+      if (!effectiveProjectId) {
+        throw new Error('Missing Weaverse projectId!')
+      }
+
+      // Build params: forward serializable load fields (type/handle/locale +
+      // any extra), dropping undefined values, cache, and projectId.
+      let params: Record<string, unknown> = {}
+      for (let [key, value] of Object.entries(rest)) {
+        if (value !== undefined) {
+          params[key] = value
+        }
+      }
+
+      let i18n = this.requestContext?.i18n ?? this.commerce?.storefront?.i18n
+      let url = normalizeNextPageUrl(resolveRequestUrl(this.requestContext))
+      let body = {
+        projectId: effectiveProjectId,
+        url,
+        i18n,
+        params,
+        isDesignMode: this._baseConfigs.isDesignMode,
+      }
+
+      let apiUrl = `${this._baseConfigs.weaverseApiBase}/api/public/project`
+      let userAgent = this.requestContext?.headers?.get('user-agent') ?? ''
+      let payload = await this.fetchWithCache<Record<string, unknown>>(apiUrl, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { ...JSON_HEADERS, 'X-Visitor-UA': userAgent },
+        ...(cache ?? {}),
+      })
+
+      if (payload && typeof payload === 'object' && 'error' in payload) {
+        let errorValue = (payload as { error?: unknown }).error
+        if (typeof errorValue === 'string') {
+          throw new Error(errorValue)
+        }
+      }
+
+      let record = (
+        payload && typeof payload === 'object' ? payload : {}
+      ) as Record<string, unknown>
+      let page = record.page as WeaverseNextPageData | undefined
+      let project = record.project as
+        | WeaverseNextLoaderData['project']
+        | undefined
+      let pageAssignment = record.pageAssignment as
+        | WeaverseNextLoaderData['pageAssignment']
+        | undefined
+
+      if (!project) {
+        project = {
+          id: effectiveProjectId,
+          name: 'Weaverse project not found.',
+          weaverseShopId: '',
+        }
+      }
+      if (!page) {
+        page = this._generateFallbackPage(
+          '<div style="text-align: center;">Please add new section to start.</div>'
+        )
+      }
+      if (Array.isArray(page.items) && page.items.length === 0) {
+        page.items.push({
+          type: 'main',
+          id: page.rootId || generateUuid(),
+          data: {},
+        })
+      }
+
+      let configs = {
+        ...this._buildPublicConfigs(effectiveProjectId),
+        requestInfo: buildWeaverseNextRequestInfo(this.requestContext),
+      }
+
+      let data: WeaverseNextLoaderData = {
+        page,
+        project,
+        pageAssignment,
+        configs,
+      }
+
+      // Run component loaders server-side so sections get their data.
+      this.data = data
+      let withLoaders = await runWeaverseComponentLoaders({
+        client: this,
+        data,
+      })
+      this.data = withLoaders ?? data
+      return this.data
+    } catch (error) {
+      console.error('❌ Page load failed', {
+        url: this.requestContext?.url,
+        projectId: input.projectId || this.configs.projectId,
+        message: error instanceof Error ? error.message : String(error),
+      })
+      return null
+    }
+  }
+
+  loadThemeSettings = async (
+    // Broad param keeps this assignable to `WeaverseNextClient.loadThemeSettings`;
+    // only the cache fields below are honored — no request-context override.
+    optionsInput:
+      | WeaverseNextThemeSettingsOptions
+      | WeaverseNextRequestContext = {}
+  ): Promise<WeaverseNextThemeSettingsResponse> => {
+    let options = optionsInput as WeaverseNextThemeSettingsOptions
+    let themeSchema = asThemeSchema(this.themeSchema)
+    let defaultThemeSettings = generateDataFromSchema(
+      this.themeSchema as SchemaType | undefined
+    )
+    let staticContent = themeSchema?.i18n?.staticContent
+
+    try {
+      let projectId = await this.resolveProjectId()
+      if (!projectId) {
+        throw new Error('Missing Weaverse projectId!')
+      }
+
+      let { isDesignMode } = this._baseConfigs
+      let url = `${this._baseConfigs.weaverseApiBase}/api/public/project_configs`
+      let result = await this.fetchWithCache<WeaverseNextThemeSettingsResponse>(
+        url,
+        {
+          method: 'POST',
+          body: JSON.stringify({ projectId, isDesignMode }),
+          headers: JSON_HEADERS,
+          revalidate: options.revalidate,
+          tags: options.tags,
+        }
+      )
+
+      if (typeof result !== 'object' || result === null) {
+        result = { theme: defaultThemeSettings }
+      }
+
+      if (themeSchema?.settings || themeSchema?.inspector) {
+        if (!result.theme || typeof result.theme !== 'object') {
+          result.theme = defaultThemeSettings
+        } else {
+          result.theme = { ...defaultThemeSettings, ...result.theme }
+        }
+      }
+
+      if (staticContent) {
+        result.staticContent = staticContent
+      }
+
+      if (isDesignMode) {
+        result = {
+          ...result,
+          schema: themeSchema
+            ? {
+                ...themeSchema,
+                settings: themeSchema.settings?.map((group) => ({
+                  ...group,
+                  inputs: group?.inputs?.map((inputItem) =>
+                    typeof inputItem?.condition === 'function'
+                      ? {
+                          ...inputItem,
+                          condition: inputItem.condition.toString(),
+                        }
+                      : inputItem
+                  ),
+                })),
+              }
+            : undefined,
+          publicEnv: this._baseConfigs.publicEnv,
+        }
+      }
+
+      return result
+    } catch (error) {
+      let errorDetails = error instanceof Error ? error.message : String(error)
+      console.error('Unable to load theme settings', errorDetails)
+      return {
+        theme: defaultThemeSettings,
+        staticContent,
+        _error: errorDetails,
+        _loadFailed: true,
+      }
+    }
+  }
+}
+
+/**
+ * Create a server-side {@link WeaverseNextServerClient} for Next.js App Router
+ * routes / server components.
+ *
+ * @example
+ * ```ts
+ * let weaverse = createWeaverseNextServerClient({
+ *   projectId: process.env.WEAVERSE_PROJECT_ID,
+ *   components,
+ *   commerce: { storefront },
+ *   requestContext: { url, headers, searchParams, i18n },
+ *   cache: { revalidate: 60, tags: ['weaverse'] },
+ * })
+ * let data = await weaverse.loadPage({ type: 'INDEX' })
+ * let theme = await weaverse.loadThemeSettings()
+ * ```
+ */
+export function createWeaverseNextServerClient(
+  config: WeaverseNextServerClientConfig
+): WeaverseNextServerClient {
+  return new NextServerClient(config)
+}
+
+export { getContextSearchParams }

--- a/packages/next/src/server/server-client.ts
+++ b/packages/next/src/server/server-client.ts
@@ -4,6 +4,7 @@ import { registerWeaverseNextComponents } from '../registry'
 import { buildWeaverseNextRequestInfo } from '../request-info'
 import type {
   WeaverseNextBaseConfigs,
+  WeaverseNextCacheConfig,
   WeaverseNextCommerceContext,
   WeaverseNextComponent,
   WeaverseNextComponentData,
@@ -22,10 +23,12 @@ import type {
   WeaverseNextThemeSettingsResponse,
 } from '../types'
 import { generateDataFromSchema } from '../utils'
-import { getContextSearchParams, getWeaverseNextConfigs } from './configs'
+import { getWeaverseNextConfigs } from './configs'
 import { normalizeNextPageUrl, resolveRequestUrl } from './normalize-page-url'
 
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000
+const RANDOM_ID_RADIX = 36
+const RANDOM_ID_SLICE_START = 2
 
 const JSON_HEADERS = {
   'Content-Type': 'application/json',
@@ -38,7 +41,7 @@ type NextRequestInit = RequestInit & {
   next?: { revalidate?: number | false; tags?: string[] }
 }
 
-type LooseThemeSchema = {
+interface LooseThemeSchema {
   i18n?: { staticContent?: Record<string, unknown> }
   inspector?: unknown[]
   settings?: {
@@ -57,7 +60,7 @@ function generateUuid(): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
     return crypto.randomUUID()
   }
-  return `id-${Math.random().toString(36).slice(2)}`
+  return `id-${Math.random().toString(RANDOM_ID_RADIX).slice(RANDOM_ID_SLICE_START)}`
 }
 
 /**
@@ -307,124 +310,123 @@ class NextServerClient implements WeaverseNextServerClient {
     }
   }
 
-  loadPage = async (
-    input: WeaverseNextLoadPageInput = {}
-  ): Promise<WeaverseNextLoaderData | null> => {
-    try {
-      let {
-        cache,
-        projectId: routeProjectId,
-        ...rest
-      } = input as WeaverseNextServerLoadPageInput
-      let effectiveProjectId =
-        (typeof routeProjectId === 'string' && routeProjectId.trim()) ||
-        (await this.resolveProjectId())
-
-      // Propagate a route-level projectId override to the public configs *before*
-      // running component loaders and returning, so `client.projectId`,
-      // `args.weaverse.projectId`, and the runtime all observe the override.
-      if (effectiveProjectId) {
-        this.configs = this._buildPublicConfigs(effectiveProjectId)
+  private _getLoadPageInput(input: WeaverseNextLoadPageInput) {
+    let {
+      cache,
+      projectId: routeProjectId,
+      ...rest
+    } = input as WeaverseNextServerLoadPageInput
+    let params: Record<string, unknown> = {}
+    for (let [key, value] of Object.entries(rest)) {
+      if (value !== undefined) {
+        params[key] = value
       }
+    }
+    return { cache, params, routeProjectId }
+  }
 
-      // Studio "section preview" mode renders a single section from its presets
-      // without a real page fetch — and must work even without a projectId.
-      if (this._baseConfigs.isPreviewMode) {
-        let previewData = this._generatePreviewData(effectiveProjectId || 'x')
-        this.data = previewData
-        return previewData
-      }
+  private async _resolveLoadPageProjectId(routeProjectId?: string) {
+    let effectiveProjectId =
+      (typeof routeProjectId === 'string' && routeProjectId.trim()) ||
+      (await this.resolveProjectId())
+    if (effectiveProjectId) {
+      this.configs = this._buildPublicConfigs(effectiveProjectId)
+    }
+    return effectiveProjectId
+  }
 
-      if (!effectiveProjectId) {
-        throw new Error('Missing Weaverse projectId!')
-      }
-
-      // Build params: forward serializable load fields (type/handle/locale +
-      // any extra), dropping undefined values, cache, and projectId.
-      let params: Record<string, unknown> = {}
-      for (let [key, value] of Object.entries(rest)) {
-        if (value !== undefined) {
-          params[key] = value
-        }
-      }
-
-      let i18n = this.requestContext?.i18n ?? this.commerce?.storefront?.i18n
-      let url = normalizeNextPageUrl(resolveRequestUrl(this.requestContext))
-      let body = {
-        projectId: effectiveProjectId,
+  private async _fetchPagePayload(
+    projectId: string,
+    params: Record<string, unknown>,
+    cache?: WeaverseNextCacheConfig
+  ) {
+    let i18n = this.requestContext?.i18n ?? this.commerce?.storefront?.i18n
+    let url = normalizeNextPageUrl(resolveRequestUrl(this.requestContext))
+    let apiUrl = `${this._baseConfigs.weaverseApiBase}/api/public/project`
+    let userAgent = this.requestContext?.headers?.get('user-agent') ?? ''
+    return this.fetchWithCache<Record<string, unknown>>(apiUrl, {
+      method: 'POST',
+      body: JSON.stringify({
+        projectId,
         url,
         i18n,
         params,
         isDesignMode: this._baseConfigs.isDesignMode,
-      }
+      }),
+      headers: { ...JSON_HEADERS, 'X-Visitor-UA': userAgent },
+      ...(cache ?? {}),
+    })
+  }
 
-      let apiUrl = `${this._baseConfigs.weaverseApiBase}/api/public/project`
-      let userAgent = this.requestContext?.headers?.get('user-agent') ?? ''
-      let payload = await this.fetchWithCache<Record<string, unknown>>(apiUrl, {
-        method: 'POST',
-        body: JSON.stringify(body),
-        headers: { ...JSON_HEADERS, 'X-Visitor-UA': userAgent },
-        ...(cache ?? {}),
+  private _assertNoPageError(payload: Record<string, unknown>) {
+    if ('error' in payload && typeof payload.error === 'string') {
+      throw new Error(payload.error)
+    }
+  }
+
+  private _createLoaderData(
+    payload: Record<string, unknown>,
+    projectId: string
+  ): WeaverseNextLoaderData {
+    this._assertNoPageError(payload)
+    let page = payload.page as WeaverseNextPageData | undefined
+    let project = payload.project as WeaverseNextLoaderData['project']
+    let pageAssignment = payload.pageAssignment as
+      | WeaverseNextLoaderData['pageAssignment']
+      | undefined
+
+    page ??= this._generateFallbackPage(
+      '<div style="text-align: center;">Please add new section to start.</div>'
+    )
+    project ??= {
+      id: projectId,
+      name: 'Weaverse project not found.',
+      weaverseShopId: '',
+    }
+    if (Array.isArray(page.items) && page.items.length === 0) {
+      page.items.push({
+        type: 'main',
+        id: page.rootId || generateUuid(),
+        data: {},
       })
+    }
 
-      if (payload && typeof payload === 'object' && 'error' in payload) {
-        let errorValue = (payload as { error?: unknown }).error
-        if (typeof errorValue === 'string') {
-          throw new Error(errorValue)
-        }
-      }
-
-      let record = (
-        payload && typeof payload === 'object' ? payload : {}
-      ) as Record<string, unknown>
-      let page = record.page as WeaverseNextPageData | undefined
-      let project = record.project as
-        | WeaverseNextLoaderData['project']
-        | undefined
-      let pageAssignment = record.pageAssignment as
-        | WeaverseNextLoaderData['pageAssignment']
-        | undefined
-
-      if (!project) {
-        project = {
-          id: effectiveProjectId,
-          name: 'Weaverse project not found.',
-          weaverseShopId: '',
-        }
-      }
-      if (!page) {
-        page = this._generateFallbackPage(
-          '<div style="text-align: center;">Please add new section to start.</div>'
-        )
-      }
-      if (Array.isArray(page.items) && page.items.length === 0) {
-        page.items.push({
-          type: 'main',
-          id: page.rootId || generateUuid(),
-          data: {},
-        })
-      }
-
-      let configs = {
-        ...this._buildPublicConfigs(effectiveProjectId),
+    return {
+      page,
+      project,
+      pageAssignment,
+      configs: {
+        ...this._buildPublicConfigs(projectId),
         requestInfo: buildWeaverseNextRequestInfo(this.requestContext),
+      },
+    }
+  }
+
+  private async _runLoaders(data: WeaverseNextLoaderData) {
+    this.data = data
+    let withLoaders = await runWeaverseComponentLoaders({ client: this, data })
+    this.data = withLoaders ?? data
+    return this.data
+  }
+
+  loadPage = async (
+    input: WeaverseNextLoadPageInput = {}
+  ): Promise<WeaverseNextLoaderData | null> => {
+    try {
+      let { cache, params, routeProjectId } = this._getLoadPageInput(input)
+      let projectId = await this._resolveLoadPageProjectId(routeProjectId)
+      if (this._baseConfigs.isPreviewMode) {
+        let previewData = this._generatePreviewData(projectId || 'x')
+        this.data = previewData
+        return previewData
+      }
+      if (!projectId) {
+        throw new Error('Missing Weaverse projectId!')
       }
 
-      let data: WeaverseNextLoaderData = {
-        page,
-        project,
-        pageAssignment,
-        configs,
-      }
-
-      // Run component loaders server-side so sections get their data.
-      this.data = data
-      let withLoaders = await runWeaverseComponentLoaders({
-        client: this,
-        data,
-      })
-      this.data = withLoaders ?? data
-      return this.data
+      let payload = await this._fetchPagePayload(projectId, params, cache)
+      let data = this._createLoaderData(payload, projectId)
+      return await this._runLoaders(data)
     } catch (error) {
       console.error('❌ Page load failed', {
         url: this.requestContext?.url,
@@ -544,4 +546,4 @@ export function createWeaverseNextServerClient(
   return new NextServerClient(config)
 }
 
-export { getContextSearchParams }
+export { getContextSearchParams } from './configs'

--- a/packages/next/src/studio-bridge.tsx
+++ b/packages/next/src/studio-bridge.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import {
   bindWeaverseNextStudioRuntime,
   type WeaverseNextRuntime,
@@ -19,6 +19,9 @@ export interface WeaverseNextStudioBridgeProps {
 /** Page-level Studio runtime binder. */
 export function WeaverseNextStudioBridge(props: WeaverseNextStudioBridgeProps) {
   let { runtime, navigate, revalidate } = props
+  let lastRuntimeRef = useRef(runtime)
+  let lastRuntimeDataRef = useRef(runtime.data)
+  let lastRequestInfoRef = useRef(runtime.requestInfo)
 
   useEffect(() => {
     if (navigate) {
@@ -45,6 +48,26 @@ export function WeaverseNextStudioBridge(props: WeaverseNextStudioBridgeProps) {
 
     return () => window.clearInterval(interval)
   }, [runtime, navigate, revalidate])
+
+  useEffect(() => {
+    if (lastRuntimeRef.current !== runtime) {
+      lastRuntimeRef.current = runtime
+      lastRuntimeDataRef.current = runtime.data
+      lastRequestInfoRef.current = runtime.requestInfo
+      return
+    }
+
+    if (
+      lastRuntimeDataRef.current === runtime.data &&
+      lastRequestInfoRef.current === runtime.requestInfo
+    ) {
+      return
+    }
+
+    lastRuntimeDataRef.current = runtime.data
+    lastRequestInfoRef.current = runtime.requestInfo
+    bindWeaverseNextStudioRuntime(runtime)
+  }, [runtime, runtime.data, runtime.requestInfo])
 
   return null
 }

--- a/packages/next/src/studio-bridge.tsx
+++ b/packages/next/src/studio-bridge.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useEffect } from 'react'
+import {
+  bindWeaverseNextStudioRuntime,
+  type WeaverseNextRuntime,
+} from './runtime'
+import type { WeaverseNextRuntimeInternal } from './types'
+
+const STUDIO_BIND_RETRY_INTERVAL_MS = 50
+const STUDIO_BIND_MAX_ATTEMPTS = 100
+
+export interface WeaverseNextStudioBridgeProps {
+  navigate?: WeaverseNextRuntimeInternal['navigate']
+  revalidate?: WeaverseNextRuntimeInternal['revalidate']
+  runtime: WeaverseNextRuntime
+}
+
+/** Page-level Studio runtime binder. */
+export function WeaverseNextStudioBridge(props: WeaverseNextStudioBridgeProps) {
+  let { runtime, navigate, revalidate } = props
+
+  useEffect(() => {
+    if (navigate) {
+      runtime.internal.navigate = navigate
+    }
+    if (revalidate) {
+      runtime.internal.revalidate = revalidate
+    }
+
+    if (bindWeaverseNextStudioRuntime(runtime) || !runtime.isDesignMode) {
+      return
+    }
+
+    let attempts = 0
+    let interval = window.setInterval(() => {
+      attempts += 1
+      if (
+        bindWeaverseNextStudioRuntime(runtime) ||
+        attempts >= STUDIO_BIND_MAX_ATTEMPTS
+      ) {
+        window.clearInterval(interval)
+      }
+    }, STUDIO_BIND_RETRY_INTERVAL_MS)
+
+    return () => window.clearInterval(interval)
+  }, [runtime, navigate, revalidate])
+
+  return null
+}

--- a/packages/next/src/studio-connect.tsx
+++ b/packages/next/src/studio-connect.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect } from 'react'
+import { resolveWeaverseNextStudioScriptSrc } from './studio-script-src'
+import type { WeaverseNextRequestContext } from './types'
+
+const loadedScriptSrcs = new Set<string>()
+
+function loadScript(src: string) {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  if (loadedScriptSrcs.has(src)) {
+    return
+  }
+
+  let existing = document.querySelector(`script[src="${src}"]`)
+  if (existing) {
+    loadedScriptSrcs.add(src)
+    return
+  }
+
+  let script = document.createElement('script')
+  script.async = true
+  script.src = src
+  document.head.appendChild(script)
+  loadedScriptSrcs.add(src)
+}
+
+export interface WeaverseNextStudioConnectProps {
+  context?: WeaverseNextRequestContext
+  storefrontHostname?: string
+}
+
+/** Root-level Studio script connector for Next client boundaries. */
+export function WeaverseNextStudioConnect(
+  props: WeaverseNextStudioConnectProps
+) {
+  useEffect(() => {
+    let context = props.context
+    if (!context && typeof window !== 'undefined') {
+      context = {
+        searchParams: new URLSearchParams(window.location.search),
+        url: window.location.href,
+      }
+    }
+
+    let src = resolveWeaverseNextStudioScriptSrc(context, {
+      storefrontHostname:
+        props.storefrontHostname ??
+        (typeof window === 'undefined' ? undefined : window.location.hostname),
+    })
+    if (src) {
+      loadScript(src)
+    }
+  }, [props.context, props.storefrontHostname])
+
+  return null
+}

--- a/packages/next/src/studio-script-src.ts
+++ b/packages/next/src/studio-script-src.ts
@@ -1,0 +1,101 @@
+import type { WeaverseNextRequestContext } from './types'
+
+const TRUSTED_STUDIO_HOSTS = new Set([
+  'https://studio.weaverse.io',
+  'https://studio.weaverse.dev',
+])
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
+  )
+}
+
+function normalizeOrigin(value: string | null): string | null {
+  if (!value) {
+    return null
+  }
+
+  try {
+    return new URL(value).origin
+  } catch {
+    return null
+  }
+}
+
+function isTrustedStudioOrigin(
+  origin: string,
+  storefrontHostname: string
+): boolean {
+  if (TRUSTED_STUDIO_HOSTS.has(origin)) {
+    return true
+  }
+
+  let hostname = new URL(origin).hostname
+  return isLoopbackHostname(hostname) && isLoopbackHostname(storefrontHostname)
+}
+
+function toSearchParams(context?: WeaverseNextRequestContext): URLSearchParams {
+  if (context?.searchParams) {
+    return new URLSearchParams(context.searchParams)
+  }
+
+  if (context?.url) {
+    let url =
+      typeof context.url === 'string'
+        ? new URL(context.url, 'http://localhost')
+        : context.url
+    return new URLSearchParams(url.searchParams)
+  }
+
+  return new URLSearchParams()
+}
+
+function last(searchParams: URLSearchParams, key: string): string | null {
+  let values = searchParams.getAll(key)
+  return values.length ? (values.at(-1) ?? null) : null
+}
+
+export interface ResolveWeaverseNextStudioScriptSrcOptions {
+  framework?: 'hydrogen' | 'next'
+  storefrontHostname?: string
+}
+
+/**
+ * Resolve the Studio script URL from request/search context. v0 intentionally
+ * reuses the existing structural Hydrogen bridge script until a concrete Builder
+ * incompatibility requires a dedicated Next bundle.
+ */
+export function resolveWeaverseNextStudioScriptSrc(
+  context?: WeaverseNextRequestContext,
+  options: ResolveWeaverseNextStudioScriptSrcOptions = {}
+): string | null {
+  let searchParams = toSearchParams(context)
+
+  let isDesignMode =
+    context?.isDesignMode ?? last(searchParams, 'isDesignMode') === 'true'
+  let isPreviewMode =
+    context?.isPreviewMode ?? last(searchParams, 'isPreviewMode') === 'true'
+  let isRevisionPreview =
+    context?.isRevisionPreview ?? Boolean(last(searchParams, '__revisionId'))
+
+  if (!(isDesignMode || isPreviewMode || isRevisionPreview)) {
+    return null
+  }
+
+  let origin = normalizeOrigin(last(searchParams, 'weaverseHost'))
+  if (!origin) {
+    return null
+  }
+
+  let storefrontHostname = options.storefrontHostname ?? 'localhost'
+  if (!isTrustedStudioOrigin(origin, storefrontHostname)) {
+    return null
+  }
+
+  let framework = options.framework ?? 'hydrogen'
+  let bundle = isDesignMode ? 'index.js' : 'preview.js'
+  let version = last(searchParams, 'weaverseVersion')
+  let url = `${origin}/static/studio/${framework}/${bundle}`
+  return version ? `${url}?v=${encodeURIComponent(version)}` : url
+}

--- a/packages/next/src/studio-script-src.ts
+++ b/packages/next/src/studio-script-src.ts
@@ -1,13 +1,17 @@
 import type { WeaverseNextRequestContext } from './types'
 
-const TRUSTED_STUDIO_HOSTS = new Set([
-  'https://studio.weaverse.io',
-  'https://studio.weaverse.dev',
-])
+/**
+ * Weaverse-controlled apex domains the Studio bridge may be served from
+ * (matched on the host itself and any subdomain), mirroring Hydrogen's
+ * `TRUSTED_STUDIO_DOMAINS`.
+ */
+const TRUSTED_STUDIO_DOMAINS = ['weaverse.io', 'weaverse.dev']
 
 function isLoopbackHostname(hostname: string): boolean {
   return (
-    hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname.endsWith('.localhost')
   )
 }
 
@@ -23,16 +27,37 @@ function normalizeOrigin(value: string | null): string | null {
   }
 }
 
+/**
+ * Whether `origin` is one we trust to serve the Studio bridge script. Matches
+ * Hydrogen's `isTrustedStudioHost`: trusts `weaverse.io` / `weaverse.dev` and
+ * their subdomains over https, plus loopback (`localhost` / `*.localhost` /
+ * `127.0.0.1`) — but only when the storefront itself is loopback (genuine
+ * local-builder dev). Loopback is the only place http is allowed; every other
+ * trusted host must be https. Arbitrary origins are rejected.
+ */
 function isTrustedStudioOrigin(
   origin: string,
   storefrontHostname: string
 ): boolean {
-  if (TRUSTED_STUDIO_HOSTS.has(origin)) {
-    return true
+  let parsed: URL
+  try {
+    parsed = new URL(origin)
+  } catch {
+    return false
   }
 
-  let hostname = new URL(origin).hostname
-  return isLoopbackHostname(hostname) && isLoopbackHostname(storefrontHostname)
+  let { hostname, protocol } = parsed
+  if (isLoopbackHostname(storefrontHostname) && isLoopbackHostname(hostname)) {
+    return protocol === 'http:' || protocol === 'https:'
+  }
+
+  if (protocol !== 'https:') {
+    return false
+  }
+
+  return TRUSTED_STUDIO_DOMAINS.some(
+    (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
+  )
 }
 
 function toSearchParams(context?: WeaverseNextRequestContext): URLSearchParams {
@@ -88,7 +113,7 @@ export function resolveWeaverseNextStudioScriptSrc(
     return null
   }
 
-  let storefrontHostname = options.storefrontHostname ?? 'localhost'
+  let storefrontHostname = options.storefrontHostname ?? ''
   if (!isTrustedStudioOrigin(origin, storefrontHostname)) {
     return null
   }

--- a/packages/next/src/theme-settings-store.ts
+++ b/packages/next/src/theme-settings-store.ts
@@ -1,0 +1,39 @@
+import type { WeaverseNextThemeSettingsStore } from './types'
+
+export interface CreateWeaverseNextThemeSettingsStoreOptions {
+  publicEnv?: Record<string, string | undefined>
+  schema?: unknown
+  settings?: Record<string, unknown>
+}
+
+/**
+ * Small external store shape compatible with the Studio bridge and React's
+ * `useSyncExternalStore` contract. The bridge calls `updateThemeSettings` during
+ * live theme edits, so keep that method name stable.
+ */
+export function createWeaverseNextThemeSettingsStore(
+  options: CreateWeaverseNextThemeSettingsStoreOptions = {}
+): WeaverseNextThemeSettingsStore {
+  let listeners = new Set<() => void>()
+  let store: WeaverseNextThemeSettingsStore = {
+    publicEnv: options.publicEnv,
+    schema: options.schema,
+    settings: { ...(options.settings ?? {}) },
+    getServerSnapshot: () => store.settings,
+    getSnapshot: () => store.settings,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    updateThemeSettings: (next: Record<string, unknown>) => {
+      store.settings = { ...store.settings, ...next }
+      for (let listener of listeners) {
+        listener()
+      }
+    },
+  }
+
+  return store
+}

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -5,6 +5,45 @@ import type {
 import type { PageType, SchemaType } from '@weaverse/schema'
 import type { ComponentType, ForwardRefExoticComponent, ReactNode } from 'react'
 
+export interface WeaverseNextRequestInfo {
+  i18n?: WeaverseNextI18n
+  pathname: string
+  queries: Record<string, string | boolean>
+  search: string
+}
+
+export interface WeaverseNextThemeSettingsStore {
+  getServerSnapshot: () => Record<string, unknown>
+  getSnapshot: () => Record<string, unknown>
+  publicEnv?: Record<string, string | undefined>
+  schema?: unknown
+  settings: Record<string, unknown>
+  subscribe: (listener: () => void) => () => void
+  updateThemeSettings: (next: Record<string, unknown>) => void
+}
+
+export interface WeaverseNextRuntimeInternal {
+  merchantOverrides?: unknown
+  navigate?: (
+    to: string,
+    options?: { preventScrollReset?: boolean } | Record<string, unknown>
+  ) => void
+  pageAssignment?: unknown
+  project?: unknown
+  revalidate?: (options?: unknown) => Promise<void> | void
+  themeSettingsStore?: WeaverseNextThemeSettingsStore
+  themeTextStore?: unknown
+}
+
+export interface WeaverseNextRuntimeConfig {
+  client?: WeaverseNextClient
+  data: WeaverseNextLoaderData
+  dataContext?: Record<string, unknown>
+  navigate?: WeaverseNextRuntimeInternal['navigate']
+  revalidate?: WeaverseNextRuntimeInternal['revalidate']
+  themeSettingsStore?: WeaverseNextThemeSettingsStore
+}
+
 /**
  * Locale/market info passed through to component loaders and the Storefront
  * client. Kept structurally close to Hydrogen's `WeaverseI18n` but without the

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -23,7 +23,6 @@ export interface WeaverseNextThemeSettingsStore {
 }
 
 export interface WeaverseNextRuntimeInternal {
-  merchantOverrides?: unknown
   navigate?: (
     to: string,
     options?: { preventScrollReset?: boolean } | Record<string, unknown>
@@ -32,7 +31,6 @@ export interface WeaverseNextRuntimeInternal {
   project?: unknown
   revalidate?: (options?: unknown) => Promise<void> | void
   themeSettingsStore?: WeaverseNextThemeSettingsStore
-  themeTextStore?: unknown
 }
 
 export interface WeaverseNextRuntimeConfig {

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -216,3 +216,158 @@ export interface WeaverseNextClient {
 
 export type WeaverseProduct = WeaverseResourcePickerData
 export type WeaverseCollection = WeaverseResourcePickerData
+
+// ─── Server client (`@weaverse/next/server`) ──────────────────────────────
+
+/**
+ * Project identifier accepted by {@link WeaverseNextServerClientConfig}. Either
+ * a static string or a (possibly async) resolver that reads the request
+ * context — matching Hydrogen's static/dynamic projectId support.
+ */
+export type WeaverseNextProjectId =
+  | string
+  | ((
+      context?: WeaverseNextRequestContext
+    ) => string | Promise<string> | undefined)
+
+/** Simple Next.js fetch cache options used for published-mode requests. */
+export interface WeaverseNextCacheConfig {
+  /** Maps to Next's `fetch(..., { next: { revalidate } })`. */
+  revalidate?: number | false
+  /** Maps to Next's `fetch(..., { next: { tags } })`. */
+  tags?: string[]
+}
+
+/**
+ * Per-request fetch options for {@link WeaverseNextServerClient.fetchWithCache}.
+ * Plain `RequestInit` plus the same simple Next cache knobs as
+ * {@link WeaverseNextCacheConfig}, so callers never need to import `next/*`.
+ */
+export interface WeaverseNextFetchOptions extends RequestInit {
+  revalidate?: number | false
+  tags?: string[]
+}
+
+/**
+ * Public, client-safe Weaverse config bundle. Mirrors Hydrogen's
+ * `WeaverseProjectConfigs` minus server secrets — `weaverseApiKey` is never
+ * included so it cannot leak into serialized loader data.
+ */
+export interface WeaverseNextConfigs {
+  isDesignMode: boolean
+  isPreviewMode: boolean
+  isRevisionPreview: boolean
+  projectId: string
+  publicEnv: Record<string, string | undefined>
+  sectionType: string
+  weaverseApiBase: string
+  weaverseHost: string
+  weaversePublicApiBase: string
+  weaverseVersion: string
+}
+
+/**
+ * Resolved base configs derived from request context + env. Includes the
+ * server-only `weaverseApiKey`, so this stays internal to the server client and
+ * is never serialized into loader data.
+ */
+export interface WeaverseNextBaseConfigs {
+  envProjectId: string
+  isDesignMode: boolean
+  isPreviewMode: boolean
+  isRevisionPreview: boolean
+  publicEnv: Record<string, string | undefined>
+  queryProjectId: string
+  sectionType: string
+  weaverseApiBase: string
+  weaverseApiKey: string
+  weaverseHost: string
+  weaverseVersion: string
+}
+
+/** Theme settings payload returned by {@link WeaverseNextServerClient.loadThemeSettings}. */
+export interface WeaverseNextThemeSettingsResponse {
+  _error?: string
+  _loadFailed?: boolean
+  merchantOverrides?: Record<string, unknown>
+  publicEnv?: Record<string, string | undefined>
+  schema?: unknown
+  staticContent?: Record<string, unknown>
+  theme?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+/**
+ * Options for {@link WeaverseNextServerClient.loadThemeSettings}. Cache knobs
+ * only — the server client always reads the request context it was created
+ * with, so there is no per-call context override.
+ */
+export interface WeaverseNextThemeSettingsOptions
+  extends WeaverseNextCacheConfig {}
+
+/**
+ * Config for {@link createWeaverseNextServerClient}. Unlike
+ * {@link WeaverseNextClientConfig} (which delegates network I/O to injected
+ * fetchers), the server client performs the real Weaverse API fetch itself, so
+ * it accepts request context, env, and cache options instead.
+ */
+export interface WeaverseNextServerClientConfig {
+  cache?: WeaverseNextCacheConfig
+  commerce?: WeaverseNextCommerceContext
+  components: WeaverseNextComponent[]
+  /** Plain env map; falls back to `process.env` for any missing key. */
+  env?: Record<string, string | undefined>
+  /** Custom `fetch` (mainly for tests); defaults to the global `fetch`. */
+  fetch?: typeof fetch
+  /** Per-request network timeout in ms. Defaults to 10s. */
+  fetchTimeoutMs?: number
+  projectId?: WeaverseNextProjectId
+  requestContext?: WeaverseNextRequestContext
+  themeSchema?: unknown
+  themeSettings?: Record<string, unknown>
+  /** Optional override for the resolved Weaverse public API base. */
+  weaverseApiBase?: string
+  /** Optional override for the resolved Weaverse host. */
+  weaverseHost?: string
+  weaverseVersion?: string
+}
+
+/**
+ * Server-side Weaverse client returned by {@link createWeaverseNextServerClient}.
+ * Closes the gap with Hydrogen's `context.weaverse.loadPage(...)` by performing
+ * the real Weaverse API fetch in Next server components/route handlers. It is
+ * also assignable to {@link WeaverseNextClient} so it can be passed straight to
+ * `runWeaverseComponentLoaders` and the renderer/runtime.
+ */
+export interface WeaverseNextServerClient extends WeaverseNextClient {
+  /** Public, client-safe resolved configs (no server secrets). */
+  configs: WeaverseNextConfigs
+  fetchWithCache: <T = unknown>(
+    url: string,
+    options?: WeaverseNextFetchOptions
+  ) => Promise<T>
+  loadPage: (
+    input?: WeaverseNextLoadPageInput
+  ) => Promise<WeaverseNextLoaderData | null>
+  /**
+   * Load theme settings. Pass cache options (`revalidate` / `tags`) only — the
+   * request context is the one the client was created with, so there is no
+   * per-call context override. The parameter is typed broadly purely to stay
+   * assignable to the base {@link WeaverseNextClient.loadThemeSettings}; any
+   * non-cache fields are ignored.
+   */
+  loadThemeSettings: (
+    options?: WeaverseNextThemeSettingsOptions | WeaverseNextRequestContext
+  ) => Promise<WeaverseNextThemeSettingsResponse>
+  /** Resolve the effective projectId (query → function → string → env). */
+  resolveProjectId: () => Promise<string>
+}
+
+/** Input for {@link WeaverseNextServerClient.loadPage}. */
+export interface WeaverseNextServerLoadPageInput
+  extends WeaverseNextLoadPageInput {
+  /** Per-call cache override merged over the client-level `cache` config. */
+  cache?: WeaverseNextCacheConfig
+  /** Route-level project override (multi-project), like Hydrogen. */
+  projectId?: string
+}

--- a/packages/next/vitest.config.ts
+++ b/packages/next/vitest.config.ts
@@ -9,8 +9,20 @@ export default defineConfig({
   root: packageRoot,
   resolve: {
     alias: {
+      '@weaverse/core': resolve(repoRoot, 'packages/core/src/index.ts'),
+      '@weaverse/react': resolve(repoRoot, 'packages/react/src/index.ts'),
+      '@weaverse/schema': resolve(repoRoot, 'packages/schema/src/index.ts'),
+      '~': resolve(repoRoot, 'packages/react/src'),
       react: resolve(repoRoot, 'node_modules/react'),
       'react-dom': resolve(repoRoot, 'node_modules/react-dom'),
+      'react/jsx-dev-runtime': resolve(
+        repoRoot,
+        'node_modules/react/jsx-dev-runtime.js'
+      ),
+      'react/jsx-runtime': resolve(
+        repoRoot,
+        'node_modules/react/jsx-runtime.js'
+      ),
     },
     dedupe: ['react', 'react-dom'],
   },


### PR DESCRIPTION
Implements the first Next.js adapter layers for `@weaverse/next`:

- Adds SDK-side Studio runtime bridge support for App Router rendering.
- Adds `@weaverse/next/server`, a server-side Weaverse client equivalent to Hydrogen's `context.weaverse.loadPage(...)` pattern.
- Adds real Weaverse API loading for page data and theme settings via the server subpath.
- Adds concise `packages/next/README.md` documenting package purpose, API surface, structure, and current limitations.

Server API added:
- `createWeaverseNextServerClient(config)` from `@weaverse/next/server`
- `weaverse.loadPage({ type, handle, locale, projectId })`
- `weaverse.loadThemeSettings()`
- `weaverse.fetchWithCache(...)`

Verification:
- `pnpm --filter @weaverse/next test` — 43 passed
- `pnpm --filter @weaverse/next typecheck`
- `pnpm --filter @weaverse/next build`
- `pnpm exec biome check packages/next/src packages/next/__tests__ packages/next/README.md packages/next/package.json --diagnostic-level=error`
- `git diff --check`

Refs Weaverse/builder#2533.
Fixes Weaverse/weaverse#502
Fixes Weaverse/weaverse#503

