### PR TITLE
Fix Next Studio draft-item request info

### DIFF
--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -668,6 +668,32 @@ describe('Studio runtime contract', () => {
     })
   })
 
+  it('should_hide_transient_draft_item_param_from_studio_request_info', () => {
+    // Arrange
+    let draftItem = JSON.stringify({
+      id: 'section',
+      data: { product: 'draft' },
+    })
+    let searchParams = new URLSearchParams(
+      `isDesignMode=true&weaverseDraftItem=${encodeURIComponent(
+        draftItem
+      )}&weaverseProjectId=project-123`
+    )
+
+    // Act
+    let requestInfo = buildWeaverseNextRequestInfo({
+      pathname: '/',
+      searchParams,
+    })
+
+    // Assert
+    expect(requestInfo).toEqual({
+      pathname: '/',
+      search: '?isDesignMode=true&weaverseProjectId=project-123',
+      queries: { isDesignMode: true, weaverseProjectId: 'project-123' },
+    })
+  })
+
   it('should_expose_theme_settings_store_with_live_update_method', () => {
     // Arrange
     let listener = vi.fn()

--- a/packages/next/__tests__/next-server.test.tsx
+++ b/packages/next/__tests__/next-server.test.tsx
@@ -145,6 +145,39 @@ describe('createWeaverseNextServerClient loadPage', () => {
     expect(configs.weaverseApiKey).toBeUndefined()
   })
 
+  it('should_preserve_design_mode_draft_item_param_for_loader_revalidation', async () => {
+    let fetchMock = makeFetch(makePagePayload())
+    let draftItem = JSON.stringify({
+      id: 'resource-section',
+      type: 'resource-picker-smoke',
+      data: { product: { handle: 'new-product' } },
+    })
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      fetch: fetchMock,
+      requestContext: {
+        url: `https://shop.example/?isDesignMode=true&_rsc=abc&weaverseDraftItem=${encodeURIComponent(
+          draftItem
+        )}&utm_source=drop`,
+      },
+    })
+
+    await client.loadPage()
+
+    let [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    let body = JSON.parse(init.body as string)
+    let url = new URL(body.url)
+    expect(body.url).toBe(
+      `https://shop.example/?isDesignMode=true&weaverseDraftItem=${encodeURIComponent(
+        draftItem
+      )}`
+    )
+    expect(url.searchParams.get('weaverseDraftItem')).toBe(draftItem)
+    expect(url.searchParams.has('_rsc')).toBe(false)
+    expect(url.searchParams.has('utm_source')).toBe(false)
+  })
+
   it('should_use_no_store_cache_in_design_mode', async () => {
     let fetchMock = makeFetch(makePagePayload())
     let client = createWeaverseNextServerClient({

--- a/packages/next/src/request-info.ts
+++ b/packages/next/src/request-info.ts
@@ -55,6 +55,24 @@ function toQueryRecord(
   return queries
 }
 
+const TRANSIENT_STUDIO_PARAMS = new Set([
+  'weaverseDraftItem',
+  // Legacy name from the original design-mode draft-item spike. Keep it out of
+  // runtime requestInfo too, in case an older Builder bundle is in front of a
+  // newer Next storefront.
+  '__weaverseDraftItem',
+])
+
+function getRequestInfoSearchParams(
+  context?: WeaverseNextRequestContext
+): URLSearchParams {
+  let searchParams = new URLSearchParams(getSearchParamsFromContext(context))
+  for (let key of TRANSIENT_STUDIO_PARAMS) {
+    searchParams.delete(key)
+  }
+  return searchParams
+}
+
 /**
  * Build the Hydrogen-like request info shape consumed by the Studio bridge.
  * Duplicate query keys keep the last value, matching `URLSearchParams` iteration
@@ -63,7 +81,7 @@ function toQueryRecord(
 export function buildWeaverseNextRequestInfo(
   context?: WeaverseNextRequestContext
 ): WeaverseNextRequestInfo {
-  let searchParams = getSearchParamsFromContext(context)
+  let searchParams = getRequestInfoSearchParams(context)
   let search = searchParams.toString()
 
   return {

--- a/packages/next/src/server/normalize-page-url.ts
+++ b/packages/next/src/server/normalize-page-url.ts
@@ -1,11 +1,14 @@
 import type { WeaverseNextRequestContext } from '../types'
 
 // Query params that influence Weaverse page resolution on the Builder:
-// revision previews, design-mode flags, and `weaverse*` control params
-// (host, version, project id). Everything else — utm_*, fbclid, gclid,
-// storefront filters — is irrelevant to which page the Builder returns and
-// would otherwise fragment any fetch cache keyed on the request body.
-const KEPT_PARAM_RE = /^(?:__revisionId|isDesignMode|weaverse)/
+// revision previews, design-mode flags, design-mode draft item overrides,
+// and `weaverse*` control params (host, version, project id). Everything
+// else — utm_*, fbclid, gclid, storefront filters — is irrelevant to which
+// page the Builder returns and would otherwise fragment any fetch cache keyed
+// on the request body. `weaverseDraftItem` is the current draft item param;
+// `__weaverseDraftItem` is kept as a legacy compatibility alias.
+const KEPT_PARAM_RE =
+  /^(?:__revisionId|__weaverseDraftItem|isDesignMode|weaverse)/
 const DATA_SUFFIX = '.data'
 
 /**


### PR DESCRIPTION
## Summary

Hide transient Studio draft-item params from `@weaverse/next` runtime request info while preserving them for server loader revalidation.

## Changes

- Strip `weaverseDraftItem` / legacy `__weaverseDraftItem` from `requestInfo.search` and `requestInfo.queries`.
- Preserve draft-item params in the Builder page API URL body so unsaved resource picks still reach loaders.
- Add regression coverage for both sides of the contract.

## Verification

- `pnpm --filter @weaverse/next test` → 58 passed
- `pnpm --filter @weaverse/next typecheck` → passed
- `pnpm --filter @weaverse/next build` → passed
- `pnpm exec biome check packages/next/src packages/next/__tests__` → passed
- Packed local tarball into Next POC node_modules; `npm run typecheck` and `npm run build` passed
- Runtime smoke: `requestInfo.search/queries` no longer include `weaverseDraftItem`
