### PR TITLE
Fix stale refreshStudio payload on Next RSC revalidation

### DIFF
--- a/.specs/2026-06-21--next-studio-bridge/work-logs.md
+++ b/.specs/2026-06-21--next-studio-bridge/work-logs.md
@@ -79,3 +79,70 @@ This is not full Studio E2E yet. Still required:
 ## Builder changes
 
 No Builder change appears necessary for this first slice. The code stays in `@weaverse/next` and maps the framework-specific internals to the existing bridge contract.
+
+## 2026-07-02 — @hta218 (with Claude): fix stale refreshStudio payload on RSC revalidation
+
+Symptom (POC "Resource picker smoke" section): picking a product in Studio ran
+the loading bar, the draft was saved, but the section kept rendering the old
+product. Publish + full Studio reload was required to see the new resource.
+
+### Root cause (SDK, `packages/next/src/runtime.ts`)
+
+The revalidation round-trip itself worked end-to-end: Builder's fetch patch
+appended `weaverseDraftItem` to the Next `_rsc` request, the server loader ran
+with the draft product handle, and the RSC response carried fresh per-item
+`loaderData`. The failure was client-side in `createWeaverseNextRuntime`:
+
+1. The reused design-mode runtime deliberately skips `setProjectData(page)`
+   (correct — the live Studio tree owns unsaved drafts), but it also dropped
+   the fresh payload entirely.
+2. `bindWeaverseNextStudioRuntime` then called
+   `studio.refreshStudio({ data: runtime.data, ... })` — the STALE live tree.
+3. Builder's `refreshStudio` merges draft structural edits with the incoming
+   payload's per-item `loaderData` (`buildRevalidatedItems`). With a stale
+   payload it merged back the OLD `loaderData`, so the section re-rendered the
+   previous resource while `revalidationVersion` still bumped — the loading bar
+   completed and the preview looked "done" with stale data.
+
+Hydrogen does not have this bug because `createWeaverseInstance` always passes
+the fresh loader params straight to `window.weaverseStudio.refreshStudio(...)`.
+
+### Fix
+
+- `createWeaverseNextRuntime` now stashes the latest server payload on the
+  runtime (`__weaverseNextLatestData`) on both the create and reuse paths,
+  without touching the design-mode live tree.
+- `bindWeaverseNextStudioRuntime` reports that stashed payload (falling back to
+  `runtime.data`) to `refreshStudio`, mirroring Hydrogen's semantics: fresh
+  data flows as a parameter; Builder owns the draft merge.
+
+### Tests
+
+- Updated `should_refresh_studio_after_reusing_runtime_with_new_page_data` —
+  it previously asserted `data: reusedRuntime.data`, codifying the bug; it now
+  asserts the fresh page items are reported.
+- Added
+  `should_report_fresh_loader_data_to_refresh_studio_when_design_mode_tree_is_stale`
+  simulating the resource-picker flow (stale live tree + fresh `loaderData`).
+
+### Verification
+
+```bash
+pnpm --filter @weaverse/next test       # 3 files, 59 tests passed
+pnpm --filter @weaverse/next typecheck  # passed
+pnpm --filter @weaverse/next build      # passed
+pnpm exec biome check packages/next/src/runtime.ts \
+  packages/next/__tests__/next-adapter.test.tsx --diagnostic-level=error  # clean
+```
+
+### Builder changes
+
+None required — the #2601 Builder changes (draft-item `_rsc` param, deferred
+refresh while silent update is pending, honored `shouldRevalidate` for
+server-only loaders) are correct; the remaining gap was SDK-side only.
+
+### Remaining manual E2E
+
+Publish/pack a new `@weaverse/next` alpha, install it in the POC, and re-run
+the resource-picker smoke: pick a product → loading bar → section renders the
+new product without publish + Studio reload.

--- a/.specs/2026-07-02--next-item-revalidation/README.md
+++ b/.specs/2026-07-02--next-item-revalidation/README.md
@@ -2,7 +2,7 @@
 
 | Field            | Value                                                    |
 | ---------------- | -------------------------------------------------------- |
-| **Status**       | draft                                                    |
+| **Status**       | in-progress                                              |
 | **Owner**        | @hta218                                                  |
 | **Issue**        | Related: [Weaverse/builder#2597](https://github.com/Weaverse/builder/issues/2597), [Weaverse/builder#2533](https://github.com/Weaverse/builder/issues/2533) |
 | **Branch**       | `feat/next-item-revalidation` (implementation; spec lands via `fix/next-stale-refresh-studio-payload`) |

--- a/.specs/2026-07-02--next-item-revalidation/README.md
+++ b/.specs/2026-07-02--next-item-revalidation/README.md
@@ -1,0 +1,43 @@
+# Feature: Per-item loader revalidation for @weaverse/next
+
+| Field            | Value                                                    |
+| ---------------- | -------------------------------------------------------- |
+| **Status**       | draft                                                    |
+| **Owner**        | @hta218                                                  |
+| **Issue**        | Related: [Weaverse/builder#2597](https://github.com/Weaverse/builder/issues/2597), [Weaverse/builder#2533](https://github.com/Weaverse/builder/issues/2533) |
+| **Branch**       | `feat/next-item-revalidation` (implementation; spec lands via `fix/next-stale-refresh-studio-payload`) |
+| **Created**      | 2026-07-02                                               |
+| **Last Updated** | 2026-07-02                                               |
+
+## Original Prompt
+
+> Option 2 is the right one, isn't it? The `@weaverse/hydrogen` package currently
+> has a per-item loader mechanism (running server side); on revalidation it only
+> needs to re-run this item's loader + revalidate (right?). If so, the
+> `@weaverse/next` package needs a similar mechanism too (expected to be doable).
+
+(Context: "Option 2" refers to replacing the `router.refresh()`-based Studio
+revalidation with a dedicated per-item loader revalidation channel, chosen over
+a header-based draft-item transport and a Builder-side scroll-lock workaround.)
+
+## Summary
+
+Studio resource-picker revalidation for Next.js currently rides on
+`router.refresh()` plus a `weaverseDraftItem` query-param rewrite of the RSC
+fetch URL. The rewritten URL changes the Next App Router page segment key, so
+applying the refreshed payload remounts the page tree — the preview scrolls to
+the top and loses client state before Builder scrolls back to the selected
+section. This spec adds a per-item loader revalidation channel to
+`@weaverse/next`: an SDK-provided route-handler factory the consumer app mounts,
+plus a client-side `internal.revalidateItem` that fetches fresh `loaderData` for
+just the edited item and applies it in place — no navigation, no remount, no
+scroll.
+
+## Supporting documents
+
+- [`plan.md`](./plan.md) — design, contract, implementation slices, verification
+
+## Precursor specs
+
+- [`../2026-06-21--next-studio-bridge/`](../2026-06-21--next-studio-bridge/) — Studio Bridge runtime contract this narrows
+- [`../2026-06-19--nextjs-adapter-contract/`](../2026-06-19--nextjs-adapter-contract/) — base `@weaverse/next` adapter contract

--- a/.specs/2026-07-02--next-item-revalidation/plan.md
+++ b/.specs/2026-07-02--next-item-revalidation/plan.md
@@ -1,0 +1,224 @@
+# Plan: Per-item loader revalidation for @weaverse/next
+
+## Problem
+
+When a Studio user edits a loader-backed input (e.g. a resource picker) on a
+Next.js App Router storefront, Builder revalidates the preview by:
+
+1. Patching `window.fetch` so `_rsc` requests carry a `weaverseDraftItem`
+   query param (the unsaved item JSON).
+2. Calling `weaverse.internal.revalidate()` → `router.refresh()`.
+
+The rewritten RSC URL changes the App Router **page segment cache key**
+(`__PAGE__?{...}` is keyed on search params), so applying the refreshed payload
+**remounts the page tree**:
+
+- the preview scrolls to the top, then Builder scrolls back to the selected
+  section (jarring double scroll);
+- client component state is lost (playing video, open drawers, form input);
+- the whole page re-renders for a single-item data change;
+- the transient draft payload leaks into the preview's canonical URL (worked
+  around today by `cleanPreviewPath()` in Builder).
+
+Hydrogen does not have this problem: React Router's `useRevalidator()` re-runs
+route loaders **in place** — no navigation, no remount. The essential semantics
+are "re-run the server-side component loader, apply fresh `loaderData` in
+place". `router.refresh()` was only ever an approximation of that.
+
+## Goals
+
+- Revalidate a single edited item's server-side loader without any router
+  navigation or RSC tree re-apply.
+- Keep the mechanism package-owned (`@weaverse/next`), with one-file wiring in
+  the consumer app, matching the existing `loadWeaversePage` pattern.
+- Keep Builder backward compatible: feature-detect the new capability, fall
+  back to the current `router.refresh()` flow for older SDK versions.
+
+## Non-goals
+
+- Replacing full-page refresh flows (`refreshPage`, locale change, page
+  import) — those still use `router.refresh()` / navigation.
+- Changing the Hydrogen revalidation path.
+- Theme-settings revalidation (unaffected; live-updated via
+  `updateThemeSettings`).
+- Removing the `weaverseDraftItem` fetch patch entirely in v1 — it remains the
+  fallback for SDKs without `revalidateItem`.
+
+## Design
+
+### Data flow
+
+```text
+Editor resource picker change
+  → Builder preview RPC: revalidate(id)
+  → feature-detect: typeof weaverse.internal.revalidateItem === 'function'
+     ├─ yes (new path):
+     │    Builder builds the draft item JSON (as today) and calls
+     │    weaverse.internal.revalidateItem(draftItem)
+     │      → SDK POSTs { draftItem } to the app's revalidate endpoint
+     │      → route handler (SDK factory) looks up the component by type,
+     │        runs its loader server-side with the draft data
+     │      → returns { loaderData }
+     │      → SDK applies: itemInstances.get(id).setData({ loaderData })
+     │      → item re-renders in place; Builder's poll observes the
+     │        loader-payload change → completion 'loader-payload'
+     └─ no (fallback): current fetch-patch + internal.revalidate() flow
+```
+
+No `router.refresh()`, no URL rewrite, no remount, no scroll.
+
+### Public API (`@weaverse/next`)
+
+Server (exported from `@weaverse/next/server`):
+
+```ts
+export function createWeaverseNextRevalidateHandler(config: {
+  /** Reuse the app's server-client factory (components + commerce context). */
+  getClient: (request: Request) => Promise<WeaverseNextServerClient>
+}): { POST: (request: Request) => Promise<Response> }
+```
+
+Consumer wiring (one file):
+
+```ts
+// app/api/weaverse/revalidate/route.ts
+import { createWeaverseNextRevalidateHandler } from '@weaverse/next/server'
+import { getWeaverseServerClient } from '@/app/weaverse-next/server'
+
+export const { POST } = createWeaverseNextRevalidateHandler({
+  getClient: (request) => getWeaverseServerClient(/* from request */),
+})
+```
+
+Client (wired automatically by `WeaverseNextStudio`):
+
+```ts
+runtime.internal.revalidateItem = async (draftItem) => {
+  let response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ draftItem }),
+  })
+  let { loaderData } = await response.json()
+  let instance = runtime.itemInstances.get(draftItem.id)
+  instance?.setData({ ...draftItem.data, loaderData })
+  runtime.triggerUpdate()
+}
+```
+
+Endpoint path: default `/api/weaverse/revalidate`, overridable via
+`WeaverseNextStudio` prop / client config (`revalidateEndpoint`).
+
+### Request/response contract
+
+```jsonc
+// POST /api/weaverse/revalidate
+{ "draftItem": { "id": "...", "type": "resource-picker-smoke", "data": { /* unsaved settings */ } } }
+
+// 200
+{ "loaderData": { /* loader output, JSON-serializable */ } }
+
+// 4xx
+{ "error": "unknown-component-type" | "missing-loader" | "invalid-payload" }
+```
+
+Handler behavior:
+
+- Resolve the component by `draftItem.type` from the client's registry; 404 on
+  unknown types (no arbitrary code paths).
+- Merge schema defaults under `draftItem.data` before calling the loader
+  (mirrors `execComponentLoader` / `runWeaverseComponentLoaders`).
+- Loader receives the same args shape as page-load loaders
+  (`{ data, weaverse, commerce }`), so component loaders need no changes.
+- Always respond `no-store`.
+
+### Security considerations
+
+The endpoint runs registered component loaders with caller-provided settings
+data. Exposure is equivalent to today's `weaverseDraftItem` URL param (any
+visitor can already trigger design-mode loader runs with arbitrary draft data
+via the page URL), and loaders only query public storefront data. Mitigations:
+
+- Only registered component types are executable; payload validated before use.
+- The handler runs loaders only — it never persists data or touches Weaverse
+  write APIs.
+- Response is `no-store`, so poisoned payloads cannot be cached.
+- Optional hardening (documented, not enforced in v1): consumers can gate the
+  route on design-mode markers / trusted `weaverseHost`.
+
+### Builder changes (companion, private spec)
+
+In `builder/studio/rpc/methods.ts#revalidate`:
+
+- If `weaverse.internal.revalidateItem` exists and a draft item param was
+  built: call it (await), skip `installDraftItemRevalidationParam` and
+  `internal.revalidate()`.
+- Completion detection is unchanged — the existing poll already observes
+  per-item loader-payload changes (`getRevalidationCompletion`), and the new
+  path changes the payload directly.
+- Fallback path (no `revalidateItem`, or the call throws/404s — e.g. the app
+  has not mounted the route) reverts to the current fetch-patch + refresh flow
+  within the same revalidation window.
+
+Logged in `builder/.specs/2026-06-21--next-studio-bridge/` work-log when
+implemented.
+
+## Files and folders touched
+
+SDK (`Weaverse/weaverse`):
+
+- `packages/next/src/server/revalidate-handler.ts` — new: route-handler factory
+- `packages/next/src/server.ts` — export the factory
+- `packages/next/src/runtime.ts` — `internal.revalidateItem` type + wiring
+- `packages/next/src/use-weaverse-next-studio.tsx` / `studio-bridge.tsx` —
+  wire `revalidateItem` (endpoint config) into the runtime internals
+- `packages/next/src/studio-router.ts` — extend internals factory if needed
+- `packages/next/src/types.ts` — contract types
+- `packages/next/__tests__/` — handler + client wiring tests
+
+Builder (`Weaverse/builder`, separate PR):
+
+- `studio/rpc/methods.ts` — feature-detect + fallback in `revalidate()`
+- `app/test/studio/rpc/` — tests
+
+POC (`Weaverse/weaverse-hydrogen-next-poc`):
+
+- `app/api/weaverse/revalidate/route.ts` — mount the handler
+
+## Implementation slices
+
+1. **Handler + contract (off-browser):** `createWeaverseNextRevalidateHandler`
+   with unit tests (unknown type, missing loader, schema-default merge, loader
+   args shape, no-store).
+2. **Client wiring:** `internal.revalidateItem` on the runtime, endpoint
+   config, apply-in-place via `setData`; tests with mocked fetch.
+3. **POC wiring + smoke:** mount the route, verify resource-picker edit updates
+   the section with **no scroll jump and no page remount**.
+4. **Builder feature-detect + fallback** (separate Builder PR), then E2E smoke
+   against local Builder.
+
+## Verification
+
+- Unit (SDK): handler contract cases; client applies `loaderData` in place and
+  triggers a re-render; fallback intact when endpoint is absent.
+- POC smoke (design mode, local Builder):
+  - pick a product → loading bar → section renders the new product;
+  - **no scroll-to-top**; viewport position preserved; selected section stays
+    in view;
+  - `window.location` never gains `weaverseDraftItem`;
+  - older-SDK fallback still works (feature flag off / route removed).
+- Hydrogen regression: existing `.data`/single-fetch revalidation tests pass
+  untouched.
+
+## Risks / open questions
+
+- **Loader args parity:** Next loaders currently receive
+  `{ data, commerce, weaverse }` via `runWeaverseComponentLoaders`; the handler
+  must construct an identical shape or loaders behave differently between page
+  load and revalidation.
+- **Endpoint discovery:** default path convention vs explicit config — start
+  with convention + override prop.
+- **Multiple runtimes per URL:** `revalidateItem` must resolve the item in the
+  owning runtime (`window.__weaverses`), not just the last-registered one.
+- **Draft payload size:** POST body avoids URL/header size limits entirely
+  (improvement over both the query-param and header transports).

--- a/.specs/2026-07-02--next-item-revalidation/work-logs.md
+++ b/.specs/2026-07-02--next-item-revalidation/work-logs.md
@@ -1,0 +1,54 @@
+# Work Logs
+
+## 2026-07-02 — @hta218 (with Claude)
+
+Implemented the full SDK slice plus companion Builder + POC wiring.
+
+### SDK (`packages/next`, on `fix/next-stale-refresh-studio-payload` / PR #478)
+
+- `src/server/revalidate-handler.ts` — `createWeaverseNextRevalidateHandler`:
+  parses/validates `{ draftItem }`, resolves the component from the client
+  registry (404 unknown type, 422 missing loader), runs the loader with the
+  same args shape as `runWeaverseComponentLoaders` (schema defaults merged
+  under draft data), returns `{ loaderData }` with `Cache-Control: no-store`.
+- `src/revalidate-item.ts` — `revalidateWeaverseNextItem`: POSTs the draft
+  item, applies `{ loaderData }` in place via `instance.setData`, throws on
+  any failure so Builder can fall back.
+- `internal.revalidateItem` added to `WeaverseNextRuntimeInternal`; wired by
+  `WeaverseNextStudio` (new `revalidateEndpoint` prop, default
+  `/api/weaverse/revalidate`) through `WeaverseNextStudioBridge`.
+- Tests: `__tests__/revalidate-item.test.ts` (handler contract + client
+  apply/fallback), 64 tests passing.
+
+### Builder (on `fix/next-rsc-resource-revalidation` / PR #2601, pending QA)
+
+- `studio/rpc/revalidation.ts` — `runPreferredRevalidation`: prefers
+  `internal.revalidateItem(draftItem)`, falls back to the legacy fetch-patch +
+  `internal.revalidate()` flow on rejection or missing capability.
+- `studio/rpc/methods.ts#revalidate` — builds the draft item object, defers
+  fetch-patch install to the refresh fallback only; completion poll unchanged
+  (per-item path completes via the `loader-payload` signal).
+- Tests: 4 new cases in `app/test/studio/rpc/revalidation.test.ts` (30 pass).
+
+### POC
+
+- `app/api/weaverse/revalidate/route.ts` mounts the handler with the app's
+  `getWeaverseServerClient`.
+- Installed the packed SDK tarball; `next build` registers the route.
+
+### Verification
+
+- SDK: test (64), typecheck, build, biome — all pass.
+- Builder: revalidation tests (30), biome, typecheck, build:studio — all pass.
+- Live endpoint smoke against the running POC dev server:
+  - valid draft item → 200 with real Storefront API `loaderData`
+    (product `unisex-fila-classic-kicks`);
+  - unknown component type → 404; invalid JSON → 400;
+  - `cache-control: no-store` on all responses.
+
+### Remaining
+
+- Browser QA in Studio: resource-picker edit should update the section with
+  NO scroll-to-top and no page remount; fallback QA with the route removed.
+- After QA: merge PR #478 + Builder PR #2601, release `@weaverse/next` alpha,
+  revert the POC tarball dependency to the npm version.

--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -872,15 +872,81 @@ describe('Studio runtime contract', () => {
     let reusedRuntime = createWeaverseNextRuntime({ client, data: nextData })
     bindWeaverseNextStudioRuntime(reusedRuntime)
 
-    // Assert
+    // Assert — refreshStudio must receive the FRESH server payload, not the
+    // (deliberately untouched) design-mode live tree on `runtime.data`.
     expect(reusedRuntime).toBe(runtime)
     expect(init).toHaveBeenCalledTimes(1)
     expect(refreshStudio).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: reusedRuntime.data,
+        data: expect.objectContaining({
+          items: nextData.page.items,
+        }),
         pageId: 'page-1',
         requestInfo: reusedRuntime.requestInfo,
       })
+    )
+    vi.stubGlobal('window', previousWindow)
+  })
+
+  it('should_report_fresh_loader_data_to_refresh_studio_when_design_mode_tree_is_stale', () => {
+    // Arrange — mirrors a resource-picker revalidation: the RSC refresh returns
+    // fresh per-item `loaderData`, while the reused design-mode runtime keeps
+    // the old live tree. Builder's refreshStudio merges draft structural edits
+    // with THIS payload's loaderData, so passing the stale tree would keep the
+    // previously selected resource rendered.
+    let previousWindow = globalThis.window
+    let init = vi.fn()
+    let refreshStudio = vi.fn()
+    let fakeWindow = {
+      weaverseStudio: { init, refreshStudio },
+    } as unknown as Window & typeof globalThis
+    vi.stubGlobal('window', fakeWindow)
+    let client = makeClient({
+      requestContext: { isDesignMode: true, pathname: '/' },
+    })
+    let staleData = {
+      page: {
+        id: 'page-1',
+        rootId: 'item-root',
+        items: [
+          {
+            id: 'item-root',
+            type: 'hero',
+            data: { product: { handle: 'old-product' } },
+            loaderData: { product: { title: 'Old Product' } },
+          },
+        ],
+      },
+    } as WeaverseNextLoaderData
+    let runtime = createWeaverseNextRuntime({ client, data: staleData })
+    bindWeaverseNextStudioRuntime(runtime)
+    let freshData = {
+      page: {
+        id: 'page-1',
+        rootId: 'item-root',
+        items: [
+          {
+            id: 'item-root',
+            type: 'hero',
+            data: { product: { handle: 'new-product' } },
+            loaderData: { product: { title: 'New Product' } },
+          },
+        ],
+      },
+    } as WeaverseNextLoaderData
+
+    // Act
+    let reusedRuntime = createWeaverseNextRuntime({ client, data: freshData })
+    bindWeaverseNextStudioRuntime(reusedRuntime)
+
+    // Assert — the live tree stays untouched (drafts preserved), but the
+    // refreshStudio payload carries the fresh loaderData.
+    expect(reusedRuntime).toBe(runtime)
+    let refreshedWith = refreshStudio.mock.calls.at(-1)?.[0] as {
+      data: { items: { loaderData?: { product?: { title?: string } } }[] }
+    }
+    expect(refreshedWith.data.items[0].loaderData?.product?.title).toBe(
+      'New Product'
     )
     vi.stubGlobal('window', previousWindow)
   })

--- a/packages/next/__tests__/revalidate-item.test.ts
+++ b/packages/next/__tests__/revalidate-item.test.ts
@@ -10,6 +10,14 @@ import type {
   WeaverseNextServerClient,
 } from '../src/types'
 
+const STATUS_OK = 200
+const STATUS_BAD_REQUEST = 400
+const STATUS_NOT_FOUND = 404
+const STATUS_UNPROCESSABLE = 422
+const STATUS_SERVER_ERROR = 500
+const RESPONDED_404_ERROR = /responded 404/
+const NO_LIVE_INSTANCE_ERROR = /No live item instance/
+
 const smokeSchema = createSchema({
   type: 'resource-smoke',
   title: 'Resource smoke',
@@ -70,7 +78,7 @@ describe('createWeaverseNextRevalidateHandler', () => {
     let body = await response.json()
 
     // Assert — loader gets the merged draft data and the page-load args shape.
-    expect(response.status).toBe(200)
+    expect(response.status).toBe(STATUS_OK)
     expect(response.headers.get('Cache-Control')).toBe('no-store')
     expect(body).toEqual({ loaderData: { product: { title: 'Fresh' } } })
     expect(loader).toHaveBeenCalledWith({
@@ -108,10 +116,10 @@ describe('createWeaverseNextRevalidateHandler', () => {
     )
 
     // Assert
-    expect(invalidJson.status).toBe(400)
-    expect(missingItem.status).toBe(400)
-    expect(missingId.status).toBe(400)
-    expect(unknownType.status).toBe(404)
+    expect(invalidJson.status).toBe(STATUS_BAD_REQUEST)
+    expect(missingItem.status).toBe(STATUS_BAD_REQUEST)
+    expect(missingId.status).toBe(STATUS_BAD_REQUEST)
+    expect(unknownType.status).toBe(STATUS_NOT_FOUND)
     expect(await unknownType.json()).toEqual({
       error: 'unknown-component-type',
     })
@@ -140,9 +148,9 @@ describe('createWeaverseNextRevalidateHandler', () => {
     }).POST(makeRequest({ draftItem }))
 
     // Assert
-    expect(missingLoader.status).toBe(422)
+    expect(missingLoader.status).toBe(STATUS_UNPROCESSABLE)
     expect(await missingLoader.json()).toEqual({ error: 'missing-loader' })
-    expect(loaderFailed.status).toBe(500)
+    expect(loaderFailed.status).toBe(STATUS_SERVER_ERROR)
     expect(await loaderFailed.json()).toEqual({ error: 'loader-failed' })
   })
 })
@@ -193,14 +201,14 @@ describe('revalidateWeaverseNextItem', () => {
     // Act + Assert — 404 route (app did not mount the handler) must reject.
     await expect(
       revalidateWeaverseNextItem(runtime, draftItem, '/missing')
-    ).rejects.toThrow(/responded 404/)
+    ).rejects.toThrow(RESPONDED_404_ERROR)
     // Unknown live instance must reject without fetching.
     await expect(
       revalidateWeaverseNextItem(runtime, {
         ...draftItem,
         id: 'ghost',
       })
-    ).rejects.toThrow(/No live item instance/)
+    ).rejects.toThrow(NO_LIVE_INSTANCE_ERROR)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     vi.unstubAllGlobals()
   })

--- a/packages/next/__tests__/revalidate-item.test.ts
+++ b/packages/next/__tests__/revalidate-item.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSchema } from '../src/index'
+import {
+  DEFAULT_REVALIDATE_ENDPOINT,
+  revalidateWeaverseNextItem,
+} from '../src/revalidate-item'
+import { createWeaverseNextRevalidateHandler } from '../src/server/revalidate-handler'
+import type {
+  WeaverseNextComponent,
+  WeaverseNextServerClient,
+} from '../src/types'
+
+const smokeSchema = createSchema({
+  type: 'resource-smoke',
+  title: 'Resource smoke',
+  settings: [
+    {
+      group: 'Content',
+      inputs: [
+        {
+          type: 'text',
+          name: 'heading',
+          label: 'Heading',
+          defaultValue: 'Default heading',
+        },
+      ],
+    },
+  ],
+})
+
+function makeServerClient(
+  components: WeaverseNextComponent[]
+): WeaverseNextServerClient {
+  return {
+    components,
+    commerce: { storefront: { query: vi.fn() } },
+    requestContext: { pathname: '/' },
+  } as unknown as WeaverseNextServerClient
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/weaverse/revalidate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+describe('createWeaverseNextRevalidateHandler', () => {
+  it('should_run_component_loader_with_schema_defaults_and_draft_data', async () => {
+    // Arrange
+    let loader = vi.fn().mockResolvedValue({ product: { title: 'Fresh' } })
+    let client = makeServerClient([
+      { default: () => null, loader, schema: smokeSchema },
+    ])
+    let { POST } = createWeaverseNextRevalidateHandler({
+      getClient: () => client,
+    })
+
+    // Act
+    let response = await POST(
+      makeRequest({
+        draftItem: {
+          id: 'item-1',
+          type: 'resource-smoke',
+          data: { product: { handle: 'new-product' } },
+        },
+      })
+    )
+    let body = await response.json()
+
+    // Assert — loader gets the merged draft data and the page-load args shape.
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+    expect(body).toEqual({ loaderData: { product: { title: 'Fresh' } } })
+    expect(loader).toHaveBeenCalledWith({
+      data: {
+        heading: 'Default heading',
+        product: { handle: 'new-product' },
+      },
+      weaverse: client,
+      context: client.requestContext,
+      commerce: client.commerce,
+    })
+  })
+
+  it('should_reject_invalid_payloads_and_unknown_types', async () => {
+    // Arrange
+    let client = makeServerClient([
+      {
+        default: () => null,
+        loader: vi.fn(),
+        schema: smokeSchema,
+      },
+    ])
+    let { POST } = createWeaverseNextRevalidateHandler({
+      getClient: () => client,
+    })
+
+    // Act
+    let invalidJson = await POST(makeRequest('not-json{'))
+    let missingItem = await POST(makeRequest({ nope: true }))
+    let missingId = await POST(
+      makeRequest({ draftItem: { type: 'resource-smoke' } })
+    )
+    let unknownType = await POST(
+      makeRequest({ draftItem: { id: 'item-1', type: 'nope' } })
+    )
+
+    // Assert
+    expect(invalidJson.status).toBe(400)
+    expect(missingItem.status).toBe(400)
+    expect(missingId.status).toBe(400)
+    expect(unknownType.status).toBe(404)
+    expect(await unknownType.json()).toEqual({
+      error: 'unknown-component-type',
+    })
+  })
+
+  it('should_report_missing_loader_and_loader_failures', async () => {
+    // Arrange
+    let noLoaderClient = makeServerClient([
+      { default: () => null, schema: smokeSchema },
+    ])
+    let throwingClient = makeServerClient([
+      {
+        default: () => null,
+        loader: vi.fn().mockRejectedValue(new Error('boom')),
+        schema: smokeSchema,
+      },
+    ])
+    let draftItem = { id: 'item-1', type: 'resource-smoke', data: {} }
+
+    // Act
+    let missingLoader = await createWeaverseNextRevalidateHandler({
+      getClient: () => noLoaderClient,
+    }).POST(makeRequest({ draftItem }))
+    let loaderFailed = await createWeaverseNextRevalidateHandler({
+      getClient: () => throwingClient,
+    }).POST(makeRequest({ draftItem }))
+
+    // Assert
+    expect(missingLoader.status).toBe(422)
+    expect(await missingLoader.json()).toEqual({ error: 'missing-loader' })
+    expect(loaderFailed.status).toBe(500)
+    expect(await loaderFailed.json()).toEqual({ error: 'loader-failed' })
+  })
+})
+
+describe('revalidateWeaverseNextItem', () => {
+  it('should_post_draft_item_and_apply_loader_data_in_place', async () => {
+    // Arrange
+    let setData = vi.fn()
+    let runtime = {
+      itemInstances: new Map([['item-1', { setData }]]),
+    }
+    let fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ loaderData: { title: 'Fresh' } }), {
+        status: 200,
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    let draftItem = {
+      id: 'item-1',
+      type: 'resource-smoke',
+      data: { product: { handle: 'new-product' } },
+    }
+
+    // Act
+    await revalidateWeaverseNextItem(runtime, draftItem)
+
+    // Assert
+    expect(fetchMock).toHaveBeenCalledWith(DEFAULT_REVALIDATE_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ draftItem }),
+    })
+    expect(setData).toHaveBeenCalledWith({ loaderData: { title: 'Fresh' } })
+    vi.unstubAllGlobals()
+  })
+
+  it('should_throw_when_endpoint_or_instance_is_missing_so_builder_can_fall_back', async () => {
+    // Arrange
+    let runtime = {
+      itemInstances: new Map([['item-1', { setData: vi.fn() }]]),
+    }
+    let fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('nope', { status: 404 }))
+    vi.stubGlobal('fetch', fetchMock)
+    let draftItem = { id: 'item-1', type: 'resource-smoke', data: {} }
+
+    // Act + Assert — 404 route (app did not mount the handler) must reject.
+    await expect(
+      revalidateWeaverseNextItem(runtime, draftItem, '/missing')
+    ).rejects.toThrow(/responded 404/)
+    // Unknown live instance must reject without fetching.
+    await expect(
+      revalidateWeaverseNextItem(runtime, {
+        ...draftItem,
+        id: 'ghost',
+      })
+    ).rejects.toThrow(/No live item instance/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    vi.unstubAllGlobals()
+  })
+})

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -36,6 +36,11 @@ export {
 } from './renderer'
 export { buildWeaverseNextRequestInfo } from './request-info'
 export {
+  DEFAULT_REVALIDATE_ENDPOINT,
+  type RevalidateItemRuntimeLike,
+  revalidateWeaverseNextItem,
+} from './revalidate-item'
+export {
   bindWeaverseNextStudioRuntime,
   createWeaverseNextRuntime,
   WeaverseNextRuntime,

--- a/packages/next/src/revalidate-item.ts
+++ b/packages/next/src/revalidate-item.ts
@@ -1,0 +1,60 @@
+import type { WeaverseNextComponentData } from './types'
+
+export const DEFAULT_REVALIDATE_ENDPOINT = '/api/weaverse/revalidate'
+
+/**
+ * Minimal runtime surface the in-place apply needs. Structural (not the
+ * concrete `WeaverseNextRuntime` class) so unit tests can drive it with a
+ * plain mock.
+ */
+export interface RevalidateItemRuntimeLike {
+  itemInstances: Map<
+    string,
+    {
+      setData: (update: Record<string, unknown>) => unknown
+    }
+  >
+}
+
+/**
+ * Studio per-item loader revalidation: POST the unsaved draft item to the
+ * app's revalidate route (see `createWeaverseNextRevalidateHandler`) and apply
+ * the returned `loaderData` to the live item instance in place.
+ *
+ * No `router.refresh()` is involved, so the RSC tree is never re-applied — no
+ * page remount, no scroll reset, and the draft payload never touches the URL.
+ *
+ * Throws on any failure (missing route, non-OK response, unknown item) so the
+ * Builder Studio bridge can detect the miss and fall back to its legacy
+ * refresh-based revalidation for this window.
+ */
+export async function revalidateWeaverseNextItem(
+  runtime: RevalidateItemRuntimeLike,
+  draftItem: WeaverseNextComponentData,
+  endpoint: string = DEFAULT_REVALIDATE_ENDPOINT
+): Promise<void> {
+  let instance = runtime.itemInstances.get(draftItem.id)
+  if (!instance) {
+    throw new Error(
+      `[weaverse-next] No live item instance for "${draftItem.id}".`
+    )
+  }
+
+  let response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ draftItem }),
+  })
+  if (!response.ok) {
+    throw new Error(
+      `[weaverse-next] Revalidate endpoint responded ${response.status}.`
+    )
+  }
+
+  let { loaderData } = (await response.json()) as { loaderData?: unknown }
+  // The item's settings were already mutated by the Studio edit; only the
+  // loader payload needs applying. `setData` merges and notifies subscribers,
+  // and the new `loaderData` identity is what Builder's revalidation poll
+  // observes for completion.
+  instance.setData({ loaderData: loaderData ?? null })
+}

--- a/packages/next/src/runtime.ts
+++ b/packages/next/src/runtime.ts
@@ -21,6 +21,7 @@ declare global {
 type StudioBoundRuntime = WeaverseNextRuntime & {
   __weaverseNextStudioBound?: boolean
   __weaverseNextRequestKey?: string
+  __weaverseNextLatestData?: WeaverseNextPageData & { rootId: string }
 }
 
 function getRuntimeWindow(): Window | undefined {
@@ -182,6 +183,14 @@ export function createWeaverseNextRuntime(
     if (!(existing.isDesignMode || nextIsDesignMode)) {
       existing.setProjectData(page)
     }
+    // Always capture the latest server payload. In design mode the live tree
+    // (`existing.data`) is deliberately left untouched above, so it goes stale
+    // after an RSC refresh — `bindWeaverseNextStudioRuntime` must report this
+    // fresh payload to `refreshStudio`, not the stale tree, or a revalidation
+    // (e.g. resource-picker pick) merges back old per-item `loaderData` and the
+    // preview keeps rendering the previous resource. Mirrors Hydrogen, which
+    // always passes the fresh loader params to `refreshStudio`.
+    existing.__weaverseNextLatestData = page
     existing.dataContext = resolveDataContext(config)
     existing.requestInfo = requestInfo
     existing.projectId = resolveProjectId(config.client, config.data, page.id)
@@ -214,6 +223,7 @@ export function createWeaverseNextRuntime(
 
   let runtime = new WeaverseNextRuntime(config) as StudioBoundRuntime
   runtime.__weaverseNextRequestKey = requestKey
+  runtime.__weaverseNextLatestData = page
   registerRuntime(runtime)
   return runtime
 }
@@ -235,8 +245,11 @@ export function bindWeaverseNextStudioRuntime(runtime: WeaverseNextRuntime) {
     return true
   }
 
+  // Report the latest server payload (fresh per-item `loaderData`), not the
+  // live tree: Builder's `refreshStudio` merges the editor draft's structural
+  // edits back on top and only takes the loader payload from this data.
   studio.refreshStudio?.({
-    data: runtime.data,
+    data: boundRuntime.__weaverseNextLatestData ?? runtime.data,
     pageId: runtime.pageId,
     requestInfo: runtime.requestInfo,
   })

--- a/packages/next/src/server.ts
+++ b/packages/next/src/server.ts
@@ -11,6 +11,11 @@ export {
   normalizeNextPageUrl,
   resolveRequestUrl,
 } from './server/normalize-page-url'
+export {
+  createWeaverseNextRevalidateHandler,
+  type WeaverseNextRevalidateHandlerConfig,
+  type WeaverseNextRevalidateRequestBody,
+} from './server/revalidate-handler'
 export { createWeaverseNextServerClient } from './server/server-client'
 export type {
   WeaverseNextBaseConfigs,

--- a/packages/next/src/server/revalidate-handler.ts
+++ b/packages/next/src/server/revalidate-handler.ts
@@ -9,6 +9,12 @@ const NO_STORE_HEADERS = {
   'Cache-Control': 'no-store',
 } as const
 
+const STATUS_OK = 200
+const STATUS_BAD_REQUEST = 400
+const STATUS_NOT_FOUND = 404
+const STATUS_UNPROCESSABLE = 422
+const STATUS_SERVER_ERROR = 500
+
 export interface WeaverseNextRevalidateHandlerConfig {
   /**
    * Reuse the app's server-client factory so the loader runs with the same
@@ -79,12 +85,12 @@ export function createWeaverseNextRevalidateHandler(
       try {
         payload = await request.json()
       } catch {
-        return json({ error: 'invalid-payload' }, 400)
+        return json({ error: 'invalid-payload' }, STATUS_BAD_REQUEST)
       }
 
       let draftItem = parseDraftItem(payload)
       if (!draftItem) {
-        return json({ error: 'invalid-payload' }, 400)
+        return json({ error: 'invalid-payload' }, STATUS_BAD_REQUEST)
       }
 
       let client: WeaverseNextServerClient
@@ -92,17 +98,17 @@ export function createWeaverseNextRevalidateHandler(
         client = await config.getClient(request)
       } catch (error) {
         console.error('❌ Revalidate handler getClient failed.', error)
-        return json({ error: 'client-init-failed' }, 500)
+        return json({ error: 'client-init-failed' }, STATUS_SERVER_ERROR)
       }
 
       let component = client.components.find(
         (candidate) => candidate?.schema?.type === draftItem.type
       )
       if (!component) {
-        return json({ error: 'unknown-component-type' }, 404)
+        return json({ error: 'unknown-component-type' }, STATUS_NOT_FOUND)
       }
       if (typeof component.loader !== 'function') {
-        return json({ error: 'missing-loader' }, 422)
+        return json({ error: 'missing-loader' }, STATUS_UNPROCESSABLE)
       }
 
       try {
@@ -117,7 +123,7 @@ export function createWeaverseNextRevalidateHandler(
           context: client.requestContext,
           commerce: client.commerce,
         })
-        return json({ loaderData: loaderData ?? null }, 200)
+        return json({ loaderData: loaderData ?? null }, STATUS_OK)
       } catch (error) {
         console.error(
           '❌ Item loader revalidation failed.',
@@ -125,7 +131,7 @@ export function createWeaverseNextRevalidateHandler(
           draftItem.id,
           error
         )
-        return json({ error: 'loader-failed' }, 500)
+        return json({ error: 'loader-failed' }, STATUS_SERVER_ERROR)
       }
     },
   }

--- a/packages/next/src/server/revalidate-handler.ts
+++ b/packages/next/src/server/revalidate-handler.ts
@@ -1,0 +1,132 @@
+import type {
+  WeaverseNextComponentData,
+  WeaverseNextServerClient,
+} from '../types'
+import { generateDataFromSchema } from '../utils'
+
+const NO_STORE_HEADERS = {
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store',
+} as const
+
+export interface WeaverseNextRevalidateHandlerConfig {
+  /**
+   * Reuse the app's server-client factory so the loader runs with the same
+   * component registry and commerce (storefront) context as page loads.
+   */
+  getClient: (
+    request: Request
+  ) => Promise<WeaverseNextServerClient> | WeaverseNextServerClient
+}
+
+/** POST body accepted by the revalidate route. */
+export interface WeaverseNextRevalidateRequestBody {
+  draftItem: WeaverseNextComponentData
+}
+
+function json(body: Record<string, unknown>, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: NO_STORE_HEADERS,
+  })
+}
+
+function parseDraftItem(payload: unknown): WeaverseNextComponentData | null {
+  if (typeof payload !== 'object' || payload === null) {
+    return null
+  }
+  let draftItem = (payload as { draftItem?: unknown }).draftItem
+  if (typeof draftItem !== 'object' || draftItem === null) {
+    return null
+  }
+  let { id, type } = draftItem as { id?: unknown; type?: unknown }
+  if (typeof id !== 'string' || !id || typeof type !== 'string' || !type) {
+    return null
+  }
+  return draftItem as WeaverseNextComponentData
+}
+
+/**
+ * Create the Studio per-item revalidation route handler.
+ *
+ * Studio design-mode edits to loader-backed inputs (e.g. resource pickers) need
+ * fresh server loader data for a single item. Re-running it through
+ * `router.refresh()` re-applies the whole RSC tree — and the draft-item query
+ * rewrite changes the App Router page segment key, remounting the page and
+ * resetting scroll. This handler runs just the edited component's `loader`
+ * with the unsaved draft settings and returns the payload for an in-place
+ * client update (see the `2026-07-02--next-item-revalidation` spec).
+ *
+ * Security: only registered component types are executable, the handler never
+ * persists anything, and responses are `no-store`. Exposure is equivalent to
+ * the existing `weaverseDraftItem` URL param, which already lets any visitor
+ * run design-mode loaders with arbitrary draft settings.
+ *
+ * @example
+ * ```ts
+ * // app/api/weaverse/revalidate/route.ts
+ * export const { POST } = createWeaverseNextRevalidateHandler({
+ *   getClient: () => getWeaverseServerClient(Promise.resolve({})),
+ * })
+ * ```
+ */
+export function createWeaverseNextRevalidateHandler(
+  config: WeaverseNextRevalidateHandlerConfig
+): { POST: (request: Request) => Promise<Response> } {
+  return {
+    POST: async (request: Request) => {
+      let payload: unknown
+      try {
+        payload = await request.json()
+      } catch {
+        return json({ error: 'invalid-payload' }, 400)
+      }
+
+      let draftItem = parseDraftItem(payload)
+      if (!draftItem) {
+        return json({ error: 'invalid-payload' }, 400)
+      }
+
+      let client: WeaverseNextServerClient
+      try {
+        client = await config.getClient(request)
+      } catch (error) {
+        console.error('❌ Revalidate handler getClient failed.', error)
+        return json({ error: 'client-init-failed' }, 500)
+      }
+
+      let component = client.components.find(
+        (candidate) => candidate?.schema?.type === draftItem.type
+      )
+      if (!component) {
+        return json({ error: 'unknown-component-type' }, 404)
+      }
+      if (typeof component.loader !== 'function') {
+        return json({ error: 'missing-loader' }, 422)
+      }
+
+      try {
+        // Same args shape as `runWeaverseComponentLoaders`, so component
+        // loaders behave identically between page load and revalidation.
+        let loaderData = await component.loader({
+          data: {
+            ...generateDataFromSchema(component.schema),
+            ...draftItem.data,
+          },
+          weaverse: client,
+          context: client.requestContext,
+          commerce: client.commerce,
+        })
+        return json({ loaderData: loaderData ?? null }, 200)
+      } catch (error) {
+        console.error(
+          '❌ Item loader revalidation failed.',
+          draftItem.type,
+          draftItem.id,
+          error
+        )
+        return json({ error: 'loader-failed' }, 500)
+      }
+    },
+  }
+}

--- a/packages/next/src/studio-bridge.tsx
+++ b/packages/next/src/studio-bridge.tsx
@@ -13,12 +13,13 @@ const STUDIO_BIND_MAX_ATTEMPTS = 100
 export interface WeaverseNextStudioBridgeProps {
   navigate?: WeaverseNextRuntimeInternal['navigate']
   revalidate?: WeaverseNextRuntimeInternal['revalidate']
+  revalidateItem?: WeaverseNextRuntimeInternal['revalidateItem']
   runtime: WeaverseNextRuntime
 }
 
 /** Page-level Studio runtime binder. */
 export function WeaverseNextStudioBridge(props: WeaverseNextStudioBridgeProps) {
-  let { runtime, navigate, revalidate } = props
+  let { runtime, navigate, revalidate, revalidateItem } = props
   let lastRuntimeRef = useRef(runtime)
   let lastRuntimeDataRef = useRef(runtime.data)
   let lastRequestInfoRef = useRef(runtime.requestInfo)
@@ -29,6 +30,9 @@ export function WeaverseNextStudioBridge(props: WeaverseNextStudioBridgeProps) {
     }
     if (revalidate) {
       runtime.internal.revalidate = revalidate
+    }
+    if (revalidateItem) {
+      runtime.internal.revalidateItem = revalidateItem
     }
 
     if (bindWeaverseNextStudioRuntime(runtime) || !runtime.isDesignMode) {
@@ -47,7 +51,7 @@ export function WeaverseNextStudioBridge(props: WeaverseNextStudioBridgeProps) {
     }, STUDIO_BIND_RETRY_INTERVAL_MS)
 
     return () => window.clearInterval(interval)
-  }, [runtime, navigate, revalidate])
+  }, [runtime, navigate, revalidate, revalidateItem])
 
   useEffect(() => {
     if (lastRuntimeRef.current !== runtime) {

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -30,6 +30,12 @@ export interface WeaverseNextRuntimeInternal {
   pageAssignment?: unknown
   project?: unknown
   revalidate?: (options?: unknown) => Promise<void> | void
+  /**
+   * Studio per-item loader revalidation. Builder feature-detects this and
+   * prefers it over the legacy `revalidate()` (`router.refresh()`) flow; it
+   * must reject on failure so Builder can fall back.
+   */
+  revalidateItem?: (draftItem: WeaverseNextComponentData) => Promise<void>
   themeSettingsStore?: WeaverseNextThemeSettingsStore
 }
 

--- a/packages/next/src/use-weaverse-next-studio.tsx
+++ b/packages/next/src/use-weaverse-next-studio.tsx
@@ -2,6 +2,10 @@
 
 import { useRouter } from 'next/navigation'
 import { useRef } from 'react'
+import {
+  DEFAULT_REVALIDATE_ENDPOINT,
+  revalidateWeaverseNextItem,
+} from './revalidate-item'
 import type { WeaverseNextRuntime } from './runtime'
 import { WeaverseNextStudioBridge } from './studio-bridge'
 import {
@@ -9,6 +13,7 @@ import {
   createWeaverseNextStudioInternals,
   type WeaverseNextStudioInternals,
 } from './studio-router'
+import type { WeaverseNextRuntimeInternal } from './types'
 
 /**
  * Resolve stable Studio `navigate` / `revalidate` callbacks from the Next App
@@ -44,6 +49,11 @@ export function useWeaverseNextStudioInternals(
 
 export interface WeaverseNextStudioProps
   extends CreateWeaverseNextStudioInternalsOptions {
+  /**
+   * Route the app mounted with `createWeaverseNextRevalidateHandler`.
+   * Defaults to `/api/weaverse/revalidate`.
+   */
+  revalidateEndpoint?: string
   runtime: WeaverseNextRuntime
 }
 
@@ -60,12 +70,34 @@ export interface WeaverseNextStudioProps
  * free of router imports.
  */
 export function WeaverseNextStudio(props: WeaverseNextStudioProps) {
-  let { runtime, replace } = props
+  let { runtime, replace, revalidateEndpoint } = props
   let { navigate, revalidate } = useWeaverseNextStudioInternals({ replace })
+  let endpoint = revalidateEndpoint ?? DEFAULT_REVALIDATE_ENDPOINT
+  // Cache per runtime+endpoint so the bridge bind effect (keyed on callback
+  // identity) doesn't re-run — and re-`refreshStudio` — on every render.
+  // `itemInstances` is a static registry shared by all Weaverse runtimes, so
+  // any live runtime reference resolves the edited item.
+  let revalidateItemRef = useRef<{
+    endpoint: string
+    revalidateItem: NonNullable<WeaverseNextRuntimeInternal['revalidateItem']>
+    runtime: WeaverseNextRuntime
+  } | null>(null)
+  if (
+    revalidateItemRef.current?.endpoint !== endpoint ||
+    revalidateItemRef.current.runtime !== runtime
+  ) {
+    revalidateItemRef.current = {
+      endpoint,
+      revalidateItem: (draftItem) =>
+        revalidateWeaverseNextItem(runtime, draftItem, endpoint),
+      runtime,
+    }
+  }
   return (
     <WeaverseNextStudioBridge
       navigate={navigate}
       revalidate={revalidate}
+      revalidateItem={revalidateItemRef.current.revalidateItem}
       runtime={runtime}
     />
   )


### PR DESCRIPTION
## Summary

Two related Studio revalidation fixes for Next.js App Router storefronts:

1. **Stale refreshStudio payload** — resource-picker edits saved the draft but kept rendering the old resource until publish + Studio reload. The reused design-mode runtime dropped the fresh RSC payload and reported its stale live tree to `refreshStudio(...)`, so Builder merged back the old `loaderData`. The runtime now stashes the latest server payload and reports it, mirroring Hydrogen's semantics.

2. **Per-item loader revalidation channel** (spec `2026-07-02--next-item-revalidation`) — the `router.refresh()`-based revalidation re-applies the whole RSC tree, and the `weaverseDraftItem` URL rewrite changes the App Router page segment key, remounting the page (preview scrolls to top, client state lost). The new channel re-runs just the edited component's server loader through an app-mounted route and applies `loaderData` in place — no refresh, no remount, no scroll.

## Changes

- Stash the latest server payload on the Next runtime and report it (not the stale live tree) to `refreshStudio` in `bindWeaverseNextStudioRuntime`
- Add `createWeaverseNextRevalidateHandler` (`@weaverse/next/server`): validates `{ draftItem }`, runs the registered component's loader with page-load arg parity, returns `{ loaderData }` with `no-store`
- Add `revalidateWeaverseNextItem` + `internal.revalidateItem`, wired by `WeaverseNextStudio` (new `revalidateEndpoint` prop, default `/api/weaverse/revalidate`); throws on failure so Builder can fall back to the legacy refresh flow
- Add specs: `2026-07-02--next-item-revalidation` (README, plan, work log) and update the Next Studio Bridge work log
- Tests: stale-payload regression tests + handler/client revalidation suite (64 passing)

## Companion

- Builder feature-detect + fallback in `studio/rpc/methods.ts#revalidate` ships via Weaverse/builder#2601
- POC mounts the route in `app/api/weaverse/revalidate/route.ts`

## Verification

- `pnpm --filter @weaverse/next test` — 64 tests passed; typecheck / build / biome clean
- Live endpoint smoke on the POC dev server: valid draft item → 200 with real Storefront API loader data; unknown type → 404; invalid JSON → 400; `cache-control: no-store`
- Manual E2E (packed tarball + local Builder): resource-picker edit updates the section live without publish + reload
- Pending browser QA: no scroll-to-top on revalidation via the per-item path