### PR TITLE
Fix Next item data refresh on locale navigation

### DIFF
--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { Weaverse } from '@weaverse/react'
 import type { ReactNode, RefObject } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
@@ -1213,9 +1214,10 @@ describe('Studio runtime contract', () => {
     vi.stubGlobal('window', previousWindow)
   })
 
-  it('should_apply_fresh_page_data_when_reusing_runtime_outside_design_mode', () => {
+  it('should_defer_fresh_page_data_until_after_render_when_reusing_runtime_outside_design_mode', () => {
     // Arrange — published/non-design reuse has no draft state, so the latest
-    // loader data must win.
+    // loader data must win, but not by emitting external-store updates during
+    // the renderer's render phase.
     let previousWindow = globalThis.window
     let fakeWindow = {} as Window &
       typeof globalThis & { __weaverses?: unknown }
@@ -1236,13 +1238,84 @@ describe('Studio runtime contract', () => {
       },
     }
 
-    // Act
+    // Act — runtime factory runs during React render.
     let reusedRuntime = createWeaverseNextRuntime({ client, data: nextData })
 
-    // Assert — same runtime, but the fresh page tree is applied.
+    // Assert — same runtime, but fresh page data is only queued until the
+    // renderer's post-commit effect flushes it.
     expect(reusedRuntime).toBe(runtime)
+    expect(setProjectData).not.toHaveBeenCalled()
+    expect(reusedRuntime.data.items).toHaveLength(1)
+    expect(reusedRuntime.pendingProjectData?.items).toHaveLength(2)
+
+    reusedRuntime.flushRenderPhaseUpdates()
+
     expect(setProjectData).toHaveBeenCalledTimes(1)
+    expect(reusedRuntime.pendingProjectData).toBeUndefined()
     expect(reusedRuntime.data.items).toHaveLength(2)
+    vi.stubGlobal('window', previousWindow)
+  })
+
+  it('should_flatten_fresh_item_data_when_locale_navigation_recreates_runtime_for_same_page', () => {
+    // Arrange — locale/client navigation serves the same page id under a new
+    // request key ('/fr-fr'), so a new runtime is built, but core
+    // `initProject()` finds the existing item instance in the process-wide
+    // `Weaverse.itemInstances` map and only calls `setData(item)` — nested
+    // `item.data` is flattened onto the store solely in the `WeaverseNextItem`
+    // constructor, so top-level props go stale.
+    let previousWindow = globalThis.window
+    let fakeWindow = {} as Window &
+      typeof globalThis & { __weaverses?: unknown }
+    vi.stubGlobal('window', fakeWindow)
+    let enData: WeaverseNextLoaderData = {
+      page: {
+        id: 'page-1',
+        rootId: 'item-root',
+        items: [{ id: 'item-root', type: 'hero', data: { text: 'Hello EN' } }],
+      },
+    }
+    let frData: WeaverseNextLoaderData = {
+      page: {
+        id: 'page-1',
+        rootId: 'item-root',
+        items: [
+          { id: 'item-root', type: 'hero', data: { text: 'Bonjour FR' } },
+        ],
+      },
+    }
+    createWeaverseNextRuntime({
+      client: makeClient({
+        requestContext: { isDesignMode: false, pathname: '/' },
+      }),
+      data: enData,
+    })
+    let existingItem = Weaverse.itemInstances.get('item-root')
+    expect(existingItem).toBeDefined()
+    let notify = vi.fn()
+    let unsubscribe = existingItem?.subscribe(notify)
+
+    // Act — same page id, different pathname → new runtime, reused item store.
+    let runtime = createWeaverseNextRuntime({
+      client: makeClient({
+        requestContext: { isDesignMode: false, pathname: '/fr-fr' },
+      }),
+      data: frData,
+    })
+
+    // Assert — the runtime data carries the fresh nested payload, and the item
+    // snapshot must expose it as a flattened top-level prop. The subscriber
+    // notification is deferred for the renderer's post-commit flush so runtime
+    // construction remains render-phase safe.
+    expect(runtime.data.items[0]?.data).toMatchObject({ text: 'Bonjour FR' })
+    let item = runtime.itemInstances.get('item-root')
+    expect(item).toBeDefined()
+    expect(item?.getSnapShot().text).toBe('Bonjour FR')
+    expect(notify).not.toHaveBeenCalled()
+
+    runtime.flushRenderPhaseUpdates()
+
+    expect(notify).toHaveBeenCalledTimes(1)
+    unsubscribe?.()
     vi.stubGlobal('window', previousWindow)
   })
 })
@@ -2330,11 +2403,16 @@ describe('item-level translation sidecar', () => {
       },
     }
 
-    // Act — non-design reuse re-applies project data (and its sidecar).
+    // Act — runtime reuse happens during render, so fresh project data (and its
+    // sidecar) is queued until the renderer's post-commit flush.
     let reused = createWeaverseNextRuntime({ client, data: secondData })
 
-    // Assert — same runtime, fresh sidecar extracted, item overlays it.
+    // Assert — same runtime, with the fresh sidecar pending until flush.
     expect(reused).toBe(runtime)
+    expect(reused.translationLocale).toBe('')
+
+    reused.flushRenderPhaseUpdates()
+
     expect(reused.translationLocale).toBe('fr')
     expect(
       reused.translationMap['tr-reuse-side-item'].heading.translatedValue

--- a/packages/next/src/item.ts
+++ b/packages/next/src/item.ts
@@ -8,6 +8,50 @@ import type {
 import { generateDataFromSchema } from './utils'
 
 /**
+ * Spread a serialized item's nested `data` field into top-level props — the
+ * shape the shared `@weaverse/react` renderer expects. Top-level fields win
+ * over nested ones, matching the constructor's original
+ * `Object.assign(store, schemaDefaults, data, rest)` merge order. Flat payloads
+ * with no nested `data` pass through unchanged.
+ */
+function flattenItemData(update: Omit<ElementData, 'id' | 'type'>) {
+  let { data, ...rest } = update
+  if (!(data && typeof data === 'object' && !Array.isArray(data))) {
+    return rest
+  }
+  return { ...data, ...rest }
+}
+
+/**
+ * While set, item `setData()` queues its subscriber notification here instead
+ * of emitting synchronously. `createWeaverseNextRuntime()` runs during React
+ * render (the renderer's `useMemo`), and constructing a runtime makes core's
+ * `initProject()` call `setData()` on reused item instances (locale/client
+ * navigation) — emitting to `useSyncExternalStore` subscribers mid-render
+ * trips React's setState-in-render warning. Data is still applied
+ * synchronously; only the emit is deferred.
+ */
+let deferredItemUpdates: Set<WeaverseNextItem> | null = null
+
+/**
+ * Run `create` with item update emissions deferred, returning its result and
+ * the items whose `setData()` fired meanwhile. The caller is responsible for
+ * calling `triggerUpdate()` on them once React has committed.
+ */
+export function collectDeferredItemUpdates<T>(
+  create: () => T
+): [T, WeaverseNextItem[]] {
+  let previousQueue = deferredItemUpdates
+  let queue = new Set<WeaverseNextItem>()
+  deferredItemUpdates = queue
+  try {
+    return [create(), [...queue]]
+  } finally {
+    deferredItemUpdates = previousQueue
+  }
+}
+
+/**
  * Item store that flattens the serialized item's nested `data` field onto the
  * store and seeds schema defaults — same shape Hydrogen produces, so the
  * shared `@weaverse/react` renderer can spread props at the top level.
@@ -27,9 +71,28 @@ export class WeaverseNextItem extends WeaverseItemStore {
 
   constructor(initialData: WeaverseNextComponentData, weaverse: Weaverse) {
     super(initialData as ElementData, weaverse)
-    let { data, ...rest } = initialData
     let schemaData = generateDataFromSchema(this.Element?.schema)
-    Object.assign(this._store, schemaData, data, rest)
+    Object.assign(this._store, schemaData, flattenItemData(initialData))
+  }
+
+  /**
+   * Flatten nested `data` on updates exactly like the constructor does. Core's
+   * `initProject()` calls `setData(item)` when a new runtime serves a page
+   * whose item instances already exist (e.g. locale/client navigation), and
+   * the inherited shallow merge would leave stale top-level props behind.
+   * Assigning through the inherited `data` setter swaps the `_store` ref,
+   * which invalidates the memoized snapshot below. The subscriber emit is
+   * queued instead of fired when a render-phase deferral is active (see
+   * `collectDeferredItemUpdates`).
+   */
+  setData = (update: Omit<ElementData, 'id' | 'type'>) => {
+    this.data = flattenItemData(update)
+    if (deferredItemUpdates) {
+      deferredItemUpdates.add(this)
+    } else {
+      this.triggerUpdate()
+    }
+    return this.data
   }
 
   /**

--- a/packages/next/src/renderer.tsx
+++ b/packages/next/src/renderer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { WeaverseRoot } from '@weaverse/react'
-import { memo, useContext, useMemo } from 'react'
+import { memo, useContext, useEffect, useLayoutEffect, useMemo } from 'react'
 import { WeaverseNextContext } from './provider'
 import { createWeaverseNextRuntime } from './runtime'
 import type {
@@ -12,6 +12,8 @@ import type {
 import { WeaverseNextStudio } from './use-weaverse-next-studio'
 
 const EMPTY_DATA_CONTEXT: Record<string, unknown> = {}
+const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect
 
 function getRenderablePage(
   data: WeaverseNextLoaderData | null | undefined
@@ -78,6 +80,10 @@ export const WeaverseNextRenderer = memo(function WeaverseNextRendererComponent(
     context?.themeSettingsStore,
     context?.translationStore,
   ])
+
+  useIsomorphicLayoutEffect(() => {
+    weaverse?.flushRenderPhaseUpdates()
+  }, [weaverse])
 
   if (!weaverse) {
     return null

--- a/packages/next/src/runtime.ts
+++ b/packages/next/src/runtime.ts
@@ -1,5 +1,9 @@
 import { Weaverse } from '@weaverse/react'
-import { ensureNextItemConstructor } from './item'
+import {
+  collectDeferredItemUpdates,
+  ensureNextItemConstructor,
+  type WeaverseNextItem,
+} from './item'
 import { buildWeaverseNextRequestInfo } from './request-info'
 import { createWeaverseNextThemeSettingsStore } from './theme-settings-store'
 import { TranslationStore } from './translation-store'
@@ -120,6 +124,24 @@ export class WeaverseNextRuntime extends Weaverse {
   translationMap: WeaverseNextTranslationMap = {}
   translationLocale = String()
   translationLanguageId = String()
+
+  /**
+   * Fresh page data captured while React was rendering. Runtime reuse happens
+   * inside the renderer's render phase (`useMemo`), where applying it through
+   * `setProjectData()` would emit item updates to `useSyncExternalStore`
+   * subscribers mid-render. The renderer applies it post-commit via
+   * `flushRenderPhaseUpdates()`. Never set on design-mode runtimes — the live
+   * Studio tree owns the page data there.
+   */
+  pendingProjectData?: WeaverseNextPageData & { rootId: string }
+
+  /**
+   * Reused item instances whose data was refreshed while this runtime was
+   * constructed during render (core `initProject()` calls `setData()` on
+   * them). Their data is already fresh; only the subscriber notification was
+   * deferred to `flushRenderPhaseUpdates()`.
+   */
+  pendingItemUpdates: WeaverseNextItem[] = []
 
   constructor(config: WeaverseNextRuntimeConfig) {
     let { client, data } = config
@@ -277,6 +299,29 @@ export class WeaverseNextRuntime extends Weaverse {
     this.extractTranslationSidecar()
     this.initProject()
   }
+
+  /**
+   * Apply updates deferred off the render phase: swap in any pending page data
+   * captured on runtime reuse, then notify items whose data was refreshed
+   * during construction. The renderer calls this from a layout effect right
+   * after commit, so subscribers re-render before paint (no content flash) and
+   * without React's setState-in-render warning.
+   */
+  flushRenderPhaseUpdates = () => {
+    let pendingData = this.pendingProjectData
+    if (pendingData) {
+      this.pendingProjectData = undefined
+      this.setProjectData(pendingData)
+    }
+
+    let pendingItems = this.pendingItemUpdates
+    if (pendingItems.length > 0) {
+      this.pendingItemUpdates = []
+      for (let item of pendingItems) {
+        item.triggerUpdate()
+      }
+    }
+  }
 }
 
 export function createWeaverseNextRuntime(
@@ -296,9 +341,16 @@ export function createWeaverseNextRuntime(
     // unsaved drafts. Reapplying loader `page` data here would clobber those
     // edits, so leave the project data untouched and let
     // `bindWeaverseNextStudioRuntime` push the latest state via `refreshStudio`.
-    // Published / preview reuse has no draft state, so fresh data still wins.
-    if (!(existing.isDesignMode || nextIsDesignMode)) {
-      existing.setProjectData(page)
+    // Published / preview reuse has no draft state, so fresh data still wins —
+    // but this factory runs during React render (the renderer's `useMemo`),
+    // and `setProjectData()` → `initProject()` → `setData()` would emit item
+    // updates to `useSyncExternalStore` subscribers mid-render (React's
+    // setState-in-render warning). Stash the page instead; the renderer
+    // applies it post-commit via `flushRenderPhaseUpdates()`.
+    if (existing.isDesignMode || nextIsDesignMode) {
+      existing.pendingProjectData = undefined
+    } else {
+      existing.pendingProjectData = page
     }
     // Always capture the latest server payload. In design mode the live tree
     // (`existing.data`) is deliberately left untouched above, so it goes stale
@@ -347,7 +399,15 @@ export function createWeaverseNextRuntime(
     return existing
   }
 
-  let runtime = new WeaverseNextRuntime(config) as StudioBoundRuntime
+  // Constructing a fresh runtime also happens during render, and core
+  // `initProject()` reuses process-wide item instances holding the same item
+  // ids (locale/client navigation recreates the runtime under a new request
+  // key) by calling `setData()` on them. Defer those subscriber emits to the
+  // renderer's post-commit `flushRenderPhaseUpdates()` as well.
+  let [runtime, refreshedItems] = collectDeferredItemUpdates(
+    () => new WeaverseNextRuntime(config) as StudioBoundRuntime
+  )
+  runtime.pendingItemUpdates = refreshedItems
   runtime.__weaverseNextRequestKey = requestKey
   runtime.__weaverseNextLatestData = page
   registerRuntime(runtime)


### PR DESCRIPTION
## Summary

- Fix `@weaverse/next` item stores so nested serialized `item.data` is re-flattened when existing item instances receive fresh page data.
- Add a regression test for locale/client navigation on the same Weaverse page id (`/` → `/fr-fr`) where the runtime data updates but rendered item props previously stayed stale.

## Root cause

`WeaverseNextItem` flattened `item.data` only in its constructor. During Next client navigation, the new RSC payload can serve the same page id under a new pathname; core `initProject()` then finds existing static item instances and calls `setData(item)` instead of constructing new items. The inherited shallow `setData()` kept stale top-level props, so content only updated after a full reload.

## Verification

- RED before fix: `pnpm exec vp test --run packages/next/__tests__/next-adapter.test.tsx -t should_flatten_fresh_item_data_when_locale_navigation_recreates_runtime_for_same_page` failed with `expected 'Hello EN' to be 'Bonjour FR'`.
- GREEN after fix: same focused test passes.
- `pnpm --filter @weaverse/next test` → 119 passed.
- `pnpm --filter @weaverse/next typecheck` → pass.
- `pnpm --filter @weaverse/next build` → pass.
- `pnpm exec biome check packages/next/src packages/next/__tests__` → pass.
- `git diff --check` → pass.
- Local POC tarball smoke on port 3335: `/` → header `FR` client navigation updates DOM text to FR without full reload; `runtime.data` and item snapshot both show FR.

## Review

Autoreview first pass approved patch and flagged one minor test null-guard; fixed. Second pass was blocked by Copilot quota (`402 quota_exceeded`), so manual fallback was used with full checks above.
