### PR TITLE
Add safe Next metadata and locale translations

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -245,7 +245,7 @@ let theme = await weaverse.loadThemeSettings()
 | Member | Description |
 | --- | --- |
 | `loadPage(input?)` | Fetches the page from `/api/public/project`, builds `WeaverseNextLoaderData`, runs component loaders, and returns page/project/config data. In section preview mode it can synthesize a single-section preview page. |
-| `loadThemeSettings(options?)` | Fetches `/api/public/project_configs`, merges schema defaults under merchant settings, returns theme settings/static content/schema data for design mode. |
+| `loadThemeSettings(options?)` | Fetches `/api/public/project_configs`, merges schema defaults under merchant settings, returns theme settings/static content/schema data for design mode. When the theme schema declares `i18n` and `requestContext.i18n` supplies both `language` and `country`, it also fetches locale static-text overrides from `/api/translation/static` in parallel and returns them as `merchantOverrides`. A failed or skipped overrides fetch never fails theme settings. |
 | `fetchCustomPages(options?)` | Fetches published custom pages from `/api/public/v1/projects/:projectId/custom-pages` for sitemap generation, paginating automatically and returning partial results if a later page fails. |
 | `fetchWithCache<T>(url, options?)` | Next-aware fetch helper. Uses `cache: 'no-store'` in design/revision preview and `next: { revalidate, tags }` in published mode. |
 | `resolveProjectId()` / `projectId` | Resolves project id from Studio query, config function/string, or env. |
@@ -284,12 +284,13 @@ Use the server entry in `generateMetadata()` to map Weaverse `page.seo` into a N
 
 ```ts
 // app/pages/[handle]/page.tsx
+import type { Metadata } from 'next'
 import { getWeaverseNextSeoMetadata } from '@weaverse/next/server'
 
 export async function generateMetadata(props: {
   params: Promise<{ handle: string }>
   searchParams: Promise<Record<string, string | string[] | undefined>>
-}) {
+}): Promise<Metadata> {
   let { handle } = await props.params
   let weaverse = await getWeaverseServerClient(props.searchParams, `/pages/${handle}`)
   let data = await weaverse.loadPage({ type: 'PAGE', handle })
@@ -297,7 +298,17 @@ export async function generateMetadata(props: {
 }
 ```
 
-The helper is pure and does not import `next/*`; its return shape is intentionally structural so the app can type it as `Metadata` if desired.
+The helper is pure and has no runtime dependency on `next`; it only imports the
+`Metadata` type. Its return value is directly assignable to Next `Metadata`.
+
+Two Builder-only SEO values are normalized so Next can always render the result:
+
+- Open Graph type `product` falls back to `website` (Next throws on `product`).
+  The other Builder types — `website`, `article`, `profile`, `video.other` — are
+  passed through unchanged.
+- Twitter card types `app` and `player` fall back to `summary`, because Builder
+  does not collect the extra descriptors those cards need (Next throws without
+  the `app` fields, and a `player` card without a player URL renders empty).
 
 ### Custom pages for sitemap generation
 

--- a/packages/next/__tests__/next-server.test.tsx
+++ b/packages/next/__tests__/next-server.test.tsx
@@ -1,7 +1,9 @@
+import type { Metadata } from 'next'
 import { describe, expect, it, vi } from 'vitest'
 import { createSchema } from '../src/index'
 import {
   createWeaverseNextServerClient,
+  formatWeaverseNextSeoMetadata,
   getWeaverseNextConfigs,
   getWeaverseNextSeoMetadata,
   normalizeNextPageUrl,
@@ -737,6 +739,78 @@ describe('getWeaverseNextSeoMetadata', () => {
   it('should_return_default_index_follow_when_seo_is_missing', () => {
     expect(getWeaverseNextSeoMetadata(null)).toEqual({
       robots: { index: true, follow: true },
+    })
+  })
+
+  it('should_be_assignable_to_next_metadata_without_an_adapter', () => {
+    // Compile-time assertions: `tsc --noEmit` fails if the helper's return
+    // type ever drifts away from Next's `Metadata`.
+    let metadata: Metadata = getWeaverseNextSeoMetadata(null)
+    let formatted: Metadata = formatWeaverseNextSeoMetadata({
+      title: 'SEO title',
+      openGraph: { type: 'article', title: 'OG title' },
+      twitter: { cardType: 'summary_large_image', title: 'Twitter title' },
+    })
+
+    expect(metadata.robots).toEqual({ index: true, follow: true })
+    expect(formatted.openGraph).toMatchObject({ type: 'article' })
+    expect(formatted.twitter).toMatchObject({ card: 'summary_large_image' })
+  })
+
+  it('should_fall_back_to_website_when_open_graph_type_is_product', () => {
+    // `product` is a Builder-only OG type; Next throws on it, so it degrades.
+    let metadata: Metadata = formatWeaverseNextSeoMetadata({
+      openGraph: { type: 'product', image: 'https://cdn.example/og.jpg' },
+    })
+
+    expect(metadata.openGraph).toEqual({
+      title: undefined,
+      description: undefined,
+      images: ['https://cdn.example/og.jpg'],
+      type: 'website',
+    })
+  })
+
+  it.each([
+    'website',
+    'article',
+    'profile',
+    'video.other',
+  ] as const)('should_preserve_open_graph_type_when_next_supports_%s', (type) => {
+    let metadata: Metadata = formatWeaverseNextSeoMetadata({
+      openGraph: { type },
+    })
+
+    expect(metadata.openGraph).toMatchObject({ type })
+  })
+
+  it.each([
+    'app',
+    'player',
+  ] as const)('should_downgrade_twitter_card_to_summary_when_builder_sends_%s', (cardType) => {
+    let metadata: Metadata = formatWeaverseNextSeoMetadata({
+      twitter: { cardType, image: 'https://cdn.example/tw.jpg' },
+    })
+
+    expect(metadata.twitter).toEqual({
+      card: 'summary',
+      title: undefined,
+      description: undefined,
+      images: ['https://cdn.example/tw.jpg'],
+    })
+  })
+
+  it('should_omit_open_graph_and_twitter_when_seo_has_no_content', () => {
+    let metadata = formatWeaverseNextSeoMetadata({
+      title: 'SEO title',
+      openGraph: {},
+      twitter: {},
+      robots: { index: false },
+    })
+
+    expect(metadata).toEqual({
+      title: 'SEO title',
+      robots: { index: false, follow: true },
     })
   })
 })

--- a/packages/next/__tests__/next-server.test.tsx
+++ b/packages/next/__tests__/next-server.test.tsx
@@ -32,6 +32,21 @@ function makeFetch(payload: unknown, { ok = true, status = 200 } = {}) {
   ) as unknown as typeof fetch & { mock: { calls: unknown[][] } }
 }
 
+/**
+ * A `fetch` double that picks its payload by matching a URL fragment, so
+ * parallel calls (project configs + translations) can return different data.
+ * A URL with no matching entry rejects, standing in for an API failure.
+ */
+function makeRoutedFetch(routes: Record<string, unknown>) {
+  return vi.fn((url: string) => {
+    let match = Object.keys(routes).find((fragment) => url.includes(fragment))
+    if (!match) {
+      throw new Error(`No route for ${url}`)
+    }
+    return Promise.resolve(jsonResponse(routes[match]))
+  }) as unknown as typeof fetch & { mock: { calls: [string, RequestInit][] } }
+}
+
 const Hero = (props: WeaverseNextComponentProps) => (
   <section>{props.heading as string}</section>
 )
@@ -526,6 +541,101 @@ describe('createWeaverseNextServerClient loadThemeSettings', () => {
     // Assert — merchant overrides preserved; static content still injected.
     expect(result.merchantOverrides).toEqual({ cart: { title: 'Panier' } })
     expect(result.staticContent).toEqual({ greeting: 'Hello' })
+  })
+
+  it('should_fetch_locale_merchant_overrides_when_schema_and_request_locale_exist', async () => {
+    // Arrange
+    let fetchMock = makeRoutedFetch({
+      project_configs: { theme: { topbarText: 'Remote topbar' } },
+      'translation/static': { cart: { title: 'Panier' } },
+    })
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      themeSchema,
+      fetch: fetchMock,
+      requestContext: {
+        url: 'https://shop.example/',
+        i18n: { language: 'FR', country: 'CA' },
+      },
+    })
+
+    // Act
+    let result = await client.loadThemeSettings()
+
+    // Assert
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://studio.weaverse.io/api/translation/static?projectId=proj-123&locale=fr-ca'
+    )
+    expect(result.merchantOverrides).toEqual({ cart: { title: 'Panier' } })
+  })
+
+  it('should_skip_merchant_overrides_fetch_when_request_has_no_locale', async () => {
+    let fetchMock = makeFetch({ theme: {} })
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      themeSchema,
+      fetch: fetchMock,
+      requestContext: {
+        url: 'https://shop.example/',
+        i18n: { language: 'FR' },
+      },
+    })
+
+    await client.loadThemeSettings()
+
+    expect(fetchMock.mock.calls).toHaveLength(1)
+  })
+
+  it('should_skip_merchant_overrides_fetch_when_theme_schema_has_no_i18n', async () => {
+    let fetchMock = makeFetch({ theme: {} })
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      themeSchema: { type: 'theme', settings: [] },
+      fetch: fetchMock,
+      requestContext: {
+        url: 'https://shop.example/',
+        i18n: { language: 'FR', country: 'CA' },
+      },
+    })
+
+    await client.loadThemeSettings()
+
+    expect(fetchMock.mock.calls).toHaveLength(1)
+  })
+
+  it('should_still_return_theme_when_merchant_overrides_fetch_fails', async () => {
+    let warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    let fetchMock = makeRoutedFetch({
+      project_configs: {
+        theme: { topbarText: 'Remote topbar' },
+        merchantOverrides: { cart: { title: 'API fallback' } },
+      },
+    })
+    let client = createWeaverseNextServerClient({
+      components: [heroComponent],
+      projectId: 'proj-123',
+      themeSchema,
+      fetch: fetchMock,
+      requestContext: {
+        url: 'https://shop.example/',
+        i18n: { language: 'FR', country: 'CA' },
+      },
+    })
+
+    let result = await client.loadThemeSettings()
+
+    expect(result._loadFailed).toBeUndefined()
+    expect(result.theme).toEqual({
+      pageWidth: 1200,
+      topbarText: 'Remote topbar',
+    })
+    expect(result.merchantOverrides).toEqual({
+      cart: { title: 'API fallback' },
+    })
+    warn.mockRestore()
   })
 
   it('should_return_fallback_with_defaults_when_api_fails', async () => {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -64,6 +64,9 @@
     "@weaverse/react": "5.16.4",
     "@weaverse/schema": "0.10.0"
   },
+  "devDependencies": {
+    "next": "16.2.9"
+  },
   "peerDependencies": {
     "next": ">=14",
     "react": ">=19",

--- a/packages/next/src/seo.ts
+++ b/packages/next/src/seo.ts
@@ -1,27 +1,27 @@
 import type { PageSEOData } from '@weaverse/schema'
+import type { Metadata } from 'next'
 import type { WeaverseNextLoaderData, WeaverseNextPageData } from './types'
 
+/** Next's own `openGraph` / `twitter` unions, reused so the helper's result
+ * is directly assignable to `Metadata` without a consumer-side adapter. */
+type NextOpenGraph = NonNullable<Metadata['openGraph']>
+type NextTwitter = NonNullable<Metadata['twitter']>
+
+/**
+ * Weaverse page SEO expressed as a subset of Next's `Metadata`. Assignable to
+ * `Metadata` as-is: `const metadata: Metadata = getWeaverseNextSeoMetadata(data)`.
+ */
 export interface WeaverseNextSeoMetadata {
   alternates?: { canonical?: string }
   description?: string
   keywords?: string
-  openGraph?: {
-    description?: string
-    images?: string[]
-    title?: string
-    type?: string
-  }
+  openGraph?: NextOpenGraph
   robots: {
     follow: boolean
     index: boolean
   }
   title?: string
-  twitter?: {
-    card?: string
-    description?: string
-    images?: string[]
-    title?: string
-  }
+  twitter?: NextTwitter
 }
 
 function hasOpenGraphContent(seo: PageSEOData['openGraph']): boolean {
@@ -30,6 +30,27 @@ function hasOpenGraphContent(seo: PageSEOData['openGraph']): boolean {
 
 function hasTwitterContent(seo: PageSEOData['twitter']): boolean {
   return Boolean(seo?.title || seo?.description || seo?.image || seo?.cardType)
+}
+
+function normalizeTwitterCard(
+  cardType: NonNullable<PageSEOData['twitter']>['cardType']
+): 'summary' | 'summary_large_image' {
+  return cardType === 'summary_large_image' ? 'summary_large_image' : 'summary'
+}
+
+/**
+ * Map a Builder Open Graph type onto Next's `OpenGraphType` union. Every
+ * Builder value except `product` exists in Next's union and is preserved
+ * verbatim; `product` is not modeled by Next and makes `generateMetadata()`
+ * throw, so it degrades to `website` — the closest renderable equivalent.
+ */
+function normalizeOpenGraphType(
+  type: NonNullable<PageSEOData['openGraph']>['type']
+): 'article' | 'profile' | 'video.other' | 'website' {
+  if (type === 'article' || type === 'profile' || type === 'video.other') {
+    return type
+  }
+  return 'website'
 }
 
 export function formatWeaverseNextSeoMetadata(
@@ -64,14 +85,18 @@ export function formatWeaverseNextSeoMetadata(
       title: openGraph?.title,
       description: openGraph?.description,
       images: openGraph?.image ? [openGraph.image] : undefined,
-      type: openGraph?.type || 'website',
+      type: normalizeOpenGraphType(openGraph?.type),
     }
   }
 
   let twitter = seo.twitter
   if (hasTwitterContent(twitter)) {
+    // Builder does not collect the descriptors Next requires for `app` cards
+    // (Next throws when they are missing) or `player` cards (which render an
+    // empty, useless card without a player URL and dimensions). Downgrade both
+    // to `summary` rather than emitting metadata Next cannot render.
     metadata.twitter = {
-      card: twitter?.cardType || 'summary',
+      card: normalizeTwitterCard(twitter?.cardType),
       title: twitter?.title,
       description: twitter?.description,
       images: twitter?.image ? [twitter.image] : undefined,

--- a/packages/next/src/server/server-client.ts
+++ b/packages/next/src/server/server-client.ts
@@ -548,6 +548,65 @@ class NextServerClient implements WeaverseNextServerClient {
     }
   }
 
+  /**
+   * Resolve the request locale (e.g. `fr-ca`) used for merchant overrides.
+   * Unlike Hydrogen — which defaults to `en`/`us` because a Hydrogen
+   * storefront always has an i18n context — Next apps may not thread one
+   * through, so a missing language or country means "no explicit locale" and
+   * the translation fetch is skipped rather than guessed.
+   */
+  private _resolveOverridesLocale(): string | undefined {
+    let i18n = this.requestContext?.i18n
+    let language =
+      typeof i18n?.language === 'string' ? i18n.language.trim() : ''
+    let country = typeof i18n?.country === 'string' ? i18n.country.trim() : ''
+    if (!(language && country)) {
+      return
+    }
+    return `${language.toLowerCase()}-${country.toLowerCase()}`
+  }
+
+  /**
+   * Fetch locale-specific static-text overrides from the translation API.
+   * Ported from Hydrogen's `fetchMerchantOverrides`: skipped entirely when the
+   * theme has no `i18n` schema (nothing translatable) or when the request has
+   * no explicit locale, and never allowed to fail theme settings.
+   */
+  private async _fetchMerchantOverrides(
+    projectId: string,
+    options: WeaverseNextThemeSettingsOptions
+  ): Promise<Record<string, unknown> | undefined> {
+    let { weaverseHost } = this._baseConfigs
+    if (!(asThemeSchema(this.themeSchema)?.i18n && projectId && weaverseHost)) {
+      return
+    }
+
+    let locale = this._resolveOverridesLocale()
+    if (!locale) {
+      return
+    }
+
+    let url = `${weaverseHost}/api/translation/static?projectId=${projectId}&locale=${locale}`
+    try {
+      let overrides = await this.fetchWithCache<Record<string, unknown>>(url, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        revalidate: options.revalidate,
+        tags: options.tags,
+      })
+      return typeof overrides === 'object' && overrides !== null
+        ? overrides
+        : undefined
+    } catch (error) {
+      // Translations are additive — a failure must not break theme settings.
+      console.warn(
+        '[WeaverseNext] Unable to load merchant overrides, using theme defaults:',
+        error instanceof Error ? error.message : String(error)
+      )
+      return
+    }
+  }
+
   loadThemeSettings = async (
     // Broad param keeps this assignable to `WeaverseNextClient.loadThemeSettings`;
     // only the cache fields below are honored — no request-context override.
@@ -568,16 +627,18 @@ class NextServerClient implements WeaverseNextServerClient {
 
       let { isDesignMode } = this._baseConfigs
       let url = `${this._baseConfigs.weaverseApiBase}/api/public/project_configs`
-      let result = await this.fetchWithCache<WeaverseNextThemeSettingsResponse>(
-        url,
-        {
+      // Project configs and locale overrides are independent reads — mirror
+      // Hydrogen and fetch them in parallel instead of serially.
+      let [result, merchantOverrides] = await Promise.all([
+        this.fetchWithCache<WeaverseNextThemeSettingsResponse>(url, {
           method: 'POST',
           body: JSON.stringify({ projectId, isDesignMode }),
           headers: JSON_HEADERS,
           revalidate: options.revalidate,
           tags: options.tags,
-        }
-      )
+        }),
+        this._fetchMerchantOverrides(projectId, options),
+      ])
 
       if (typeof result !== 'object' || result === null) {
         result = { theme: defaultThemeSettings }
@@ -593,6 +654,12 @@ class NextServerClient implements WeaverseNextServerClient {
 
       if (staticContent) {
         result.staticContent = staticContent
+      }
+
+      // Only overwrite when the translation API actually returned overrides so
+      // a missing/failed fetch can't wipe overrides shipped by project_configs.
+      if (merchantOverrides) {
+        result.merchantOverrides = merchantOverrides
       }
 
       if (isDesignMode) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,15 +163,16 @@ importers:
       '@weaverse/schema':
         specifier: 0.10.0
         version: 0.10.0
-      next:
-        specifier: '>=14'
-        version: 16.2.9(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: '>=19'
         version: 19.2.5
       react-dom:
         specifier: '>=19'
         version: 19.2.5(react@19.2.5)
+    devDependencies:
+      next:
+        specifier: 16.2.9
+        version: 16.2.9(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   packages/react:
     dependencies:


### PR DESCRIPTION
## Summary

- map Studio page SEO into native, runtime-safe Next.js metadata
- normalize unsupported Open Graph/Twitter discriminators instead of emitting incomplete metadata
- load locale-specific merchant overrides alongside theme settings, with resilient fallback behavior
- declare Next as a package-local build dependency and document the new behavior

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @weaverse/next typecheck`
- Biome check on changed SDK files
- `pnpm --filter @weaverse/next test` — 135 passed
- `pnpm --filter @weaverse/next build`
- Next 16 webpack prerender regression: `og:type=website`, `twitter:card=summary`, no Twitter app tags
- packed tarball in the real Next POC: typecheck, lint, build
- packed locale probe: `fr-fr` translation request and merchant override merge verified

Refs Weaverse/builder#2663
Refs Weaverse/builder#2706
