### PR TITLE
Fix reused Next item runtime bindings

### DIFF
--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -1356,6 +1356,84 @@ describe('Studio runtime contract', () => {
     unsubscribe?.()
     vi.stubGlobal('window', previousWindow)
   })
+
+  it('should_rebind_reused_item_instances_to_the_new_runtime_when_locale_navigation_recreates_runtime', () => {
+    // Arrange — same page/item id served under two locales. Core keeps item
+    // stores in the process-wide `Weaverse.itemInstances` map, so the FR
+    // runtime reuses the EN store; without rebinding, `item.weaverse` still
+    // points at the EN runtime and `getSnapShot()` reads the EN translation
+    // sidecar / `requestInfo`.
+    let previousWindow = globalThis.window
+    let fakeWindow = {} as Window &
+      typeof globalThis & { __weaverses?: unknown }
+    vi.stubGlobal('window', fakeWindow)
+    let enData: WeaverseNextLoaderData = {
+      page: {
+        id: 'rebind-page',
+        rootId: 'rebind-item',
+        items: [{ id: 'rebind-item', type: 'hero', data: { text: 'Hello' } }],
+        translationMap: {
+          'rebind-item': {
+            text: { originalValue: 'Hello', translatedValue: 'Hello EN' },
+          },
+        },
+        translationLocale: 'en-us',
+        translationLanguageId: 'lang-en',
+      },
+    }
+    let frData: WeaverseNextLoaderData = {
+      page: {
+        id: 'rebind-page',
+        rootId: 'rebind-item',
+        items: [{ id: 'rebind-item', type: 'hero', data: { text: 'Hello' } }],
+        translationMap: {
+          'rebind-item': {
+            text: { originalValue: 'Hello', translatedValue: 'Bonjour FR' },
+          },
+        },
+        translationLocale: 'fr-fr',
+        translationLanguageId: 'lang-fr',
+      },
+    }
+    let enRuntime = createWeaverseNextRuntime({
+      client: makeClient({
+        requestContext: {
+          isDesignMode: false,
+          pathname: '/',
+          i18n: { country: 'US', language: 'EN', locale: 'en-US' },
+        },
+      }),
+      data: enData,
+    })
+    let enItem = enRuntime.itemInstances.get('rebind-item')
+    expect(enItem?.weaverse).toBe(enRuntime)
+    expect(enItem?.getSnapShot().text).toBe('Hello EN')
+
+    // Act — new pathname → new request key → freshly constructed FR runtime.
+    let frRuntime = createWeaverseNextRuntime({
+      client: makeClient({
+        requestContext: {
+          isDesignMode: false,
+          pathname: '/fr-fr',
+          i18n: { country: 'FR', language: 'FR', locale: 'fr-FR' },
+        },
+      }),
+      data: frData,
+    })
+
+    // Assert — new runtime, same reused item store, but rebound to FR so its
+    // snapshot resolves through the FR sidecar and FR request info.
+    expect(frRuntime).not.toBe(enRuntime)
+    let frItem = frRuntime.itemInstances.get('rebind-item')
+    expect(frItem).toBe(enItem)
+    expect(frItem?.weaverse).toBe(frRuntime)
+    expect(frItem?.weaverse.requestInfo).toMatchObject({
+      pathname: '/fr-fr',
+      i18n: { locale: 'fr-FR' },
+    })
+    expect(frItem?.getSnapShot().text).toBe('Bonjour FR')
+    vi.stubGlobal('window', previousWindow)
+  })
 })
 
 // ─── 7. Multi-runtime / nested instance selection ─────────────────────

--- a/packages/next/src/runtime.ts
+++ b/packages/next/src/runtime.ts
@@ -107,6 +107,37 @@ function registerRuntime(runtime: WeaverseNextRuntime) {
   runtimeWindow.__weaverse = runtime
 }
 
+/**
+ * Lifecycle invariant: every item store rendered by a runtime must point back
+ * at that same runtime (`item.weaverse === runtime`).
+ *
+ * Core keeps `Weaverse.itemInstances` process-wide and keyed by item id only,
+ * so a client navigation that recreates the runtime under a new request key
+ * (e.g. `/` → `/fr-fr`) reuses the existing stores and merely calls
+ * `setData()` on them — their `weaverse` back-reference is never updated and
+ * keeps pointing at the previous runtime. Anything an item reads through that
+ * reference then stays stale: `WeaverseNextItem.getSnapShot()` reads
+ * `this.weaverse.translationMap` (locale sidecar), and `Element` /
+ * `requestInfo` consumers read the old locale's runtime until a full reload
+ * builds clean instances.
+ *
+ * Rebind only the items belonging to the freshly rendered page — other
+ * runtimes co-located on the same document own their own item ids and must
+ * keep their bindings.
+ */
+function rebindPageItemsToRuntime(runtime: WeaverseNextRuntime) {
+  let items = (runtime.data as WeaverseNextPageData | undefined)?.items
+  if (!items) {
+    return
+  }
+  for (let { id } of items) {
+    let instance = runtime.itemInstances.get(id) as WeaverseNextItem | undefined
+    if (instance && instance.weaverse !== runtime) {
+      instance.weaverse = runtime
+    }
+  }
+}
+
 export class WeaverseNextRuntime extends Weaverse {
   pageId: string
   internal: WeaverseNextRuntimeInternal
@@ -408,6 +439,11 @@ export function createWeaverseNextRuntime(
     () => new WeaverseNextRuntime(config) as StudioBoundRuntime
   )
   runtime.pendingItemUpdates = refreshedItems
+  // Reused stores are still bound to the runtime that built them; rebind before
+  // returning so consumers read snapshots through this runtime (see
+  // `rebindPageItemsToRuntime`). Rebinding touches no subscriber, so it stays
+  // render-phase safe alongside the deferred item updates above.
+  rebindPageItemsToRuntime(runtime)
   runtime.__weaverseNextRequestKey = requestKey
   runtime.__weaverseNextLatestData = page
   registerRuntime(runtime)


### PR DESCRIPTION
## Summary

Fix locale client navigation keeping reused Weaverse item stores bound to the previous runtime.

- Rebind only current-page item instances when a new request-key runtime is created.
- Preserve item identity and deferred subscriber updates while using the active locale's request info and translation sidecar.
- Add an EN → FR regression test covering reused identity, runtime rebinding, and translated snapshots.

## Verification

- `pnpm --filter @weaverse/next typecheck`
- `pnpm exec biome check packages/next/src/runtime.ts packages/next/__tests__/next-adapter.test.tsx`
- `pnpm --filter @weaverse/next test` — 136 passed
- `pnpm --filter @weaverse/next build`
- Packed SDK in the real Next POC: typecheck, lint, build, and browser EN ↔ FR runtime-identity smoke passed
