### PR TITLE
docs(next): specify route-aware item revalidation

### DIFF
--- a/.specs/2026-07-22--next-route-context-revalidation/README.md
+++ b/.specs/2026-07-22--next-route-context-revalidation/README.md
@@ -1,0 +1,37 @@
+# Fix: Preserve route context during Next per-item revalidation
+
+| Field | Value |
+| --- | --- |
+| **Status** | in-progress |
+| **Owner** | @hta218 |
+| **Issue** | [Weaverse/builder#2737](https://github.com/Weaverse/builder/issues/2737) |
+| **Branch** | `docs/next-route-context-revalidation` |
+| **Created** | 2026-07-22 |
+| **Last Updated** | 2026-07-22 |
+
+## Original Prompt
+
+> `@weaverse/next` supports per-item Studio revalidation, but the current request contract carries only `draftItem`. The POC revalidation route constructs its server client with the default `/` context, so loaders on product, collection, custom, localized, or search-dependent routes can run without the original pathname, locale, and search parameters.
+>
+> The simple resource-picker smoke works because its loader does not depend on route context. This does not prove correctness for production loaders.
+
+## Spec Request
+
+> Okay, that's right. Describe it carefully, create a branch and detailed specs (you write them), then commit, push, and open a PR.
+
+## Summary
+
+Next per-item revalidation currently loses the owning storefront route, so loaders on localized or query-dependent pages can run with `/`, no locale, and empty search state. This spec adds a sanitized route-context envelope, reconstructs a server request context in the handler, and keeps project, host, credentials, and environment server-owned. The existing in-place update, no-remount behavior, and Builder fallback remain unchanged.
+
+## Supporting documents
+
+- [`plan.md`](./plan.md) — contracts, trust boundary, implementation slices, and verification matrix
+- [`security-contract.md`](./security-contract.md) — normative validation, sanitization, and origin-safety rules
+- [`implementation-handoff.md`](./implementation-handoff.md) — ordered TDD handoff for the implementation agent
+- [`work-logs.md`](./work-logs.md) — investigation and decision log
+
+## Related specs
+
+- [`../2026-07-02--next-item-revalidation/`](../2026-07-02--next-item-revalidation/) — original in-place revalidation channel
+- [`../2026-06-21--next-studio-bridge/`](../2026-06-21--next-studio-bridge/) — Next Studio bridge contract
+- [`../2026-06-19--nextjs-adapter-contract/`](../2026-06-19--nextjs-adapter-contract/) — base Next adapter contract

--- a/.specs/2026-07-22--next-route-context-revalidation/implementation-handoff.md
+++ b/.specs/2026-07-22--next-route-context-revalidation/implementation-handoff.md
@@ -1,0 +1,113 @@
+# Implementation handoff: Next route-context revalidation
+
+Implement [Weaverse/builder#2737](https://github.com/Weaverse/builder/issues/2737)
+from [`plan.md`](./plan.md). Read the original revalidation spec and the current
+source before editing. Use TDD: add each focused failing test, run it to confirm
+the expected failure, then make the minimum implementation pass.
+
+## Repositories
+
+1. SDK: `Weaverse/weaverse`
+2. Consumer verification: `Weaverse/weaverse-hydrogen-next-poc`
+3. Builder: read-only verification only; no contract change is expected
+
+## Required behavior
+
+- `internal.revalidateItem(draftItem)` remains unchanged for Builder.
+- The SDK POST includes a sanitized route snapshot when runtime context exists.
+- The route handler validates the snapshot, reconstructs a
+  `WeaverseNextRequestContext`, and passes it to the consumer factory.
+- Registered component loaders receive a client whose `requestContext` matches
+  the active storefront route.
+- Browser input cannot choose project ID, Weaverse host, API base, API key, or
+  server env.
+- In-place loader application, fallback behavior, and scroll continuity remain
+  unchanged.
+
+## Ordered TDD slices
+
+### 1. Request-info route identity
+
+1. Add failing tests showing `buildWeaverseNextRequestInfo()` preserves optional
+   `pageType` and `handle` from `WeaverseNextRequestContext`.
+2. Add the two optional fields to `WeaverseNextRequestInfo` and its builder.
+3. Run the focused request-info/runtime tests.
+
+### 2. Client route-context serialization
+
+1. Extend the test runtime with `requestInfo`.
+2. Add a failing test whose search contains normal route state plus malicious or
+   transient Weaverse controls.
+3. Implement the route-context serializer in `revalidate-item.ts`.
+4. Assert the POST keeps pathname, duplicate/encoded ordinary query values,
+   locale/i18n, page type, and handle while removing every denied control.
+5. Keep `requestInfo` optional on the structural runtime type; when absent, omit
+   `routeContext` for compatibility.
+
+### 3. Handler validation and reconstruction
+
+1. Add failing tests for a valid localized PDP context.
+2. Extend `getClient` with an optional second `requestContext` argument.
+3. Validate and sanitize `routeContext` before client creation.
+4. Reconstruct pathname, `URLSearchParams`, same-origin URL, i18n, page type,
+   handle, and mode flags.
+5. Prove the registered loader receives that reconstructed context through the
+   returned client's `requestContext`.
+6. Add hostile path/search/control-param tests and legacy missing-context test.
+
+### 4. POC route factory
+
+1. Refactor the POC server-client helper so page routes can pass `pageType` and
+   `handle`, and the revalidation route can pass an explicit request context.
+2. Update Product, Collection, Index, and Custom load boundaries as appropriate.
+3. Update the client wrapper to restore `pageType` and `handle` from serialized
+   `configs.requestInfo`.
+4. Wire the revalidation handler callback's second argument into the explicit
+   server-client path.
+5. Extend the existing real Storefront API smoke loader response with a compact
+   route-context snapshot used only as QA evidence; do not replace Shopify data
+   with fixtures or fallback demo data.
+
+### 5. Documentation and compatibility
+
+1. Update package README route-handler wiring.
+2. Document that `requestContext` is validated browser input and project/host/env
+   must still come from server config.
+3. Keep the old one-argument `getClient` callback example valid.
+4. Run package tests, typecheck, build, and formatting/lint checks.
+
+### 6. Packed consumer and Studio QA
+
+1. Build and pack the final SDK candidate.
+2. Install the tarball in the real POC without committing registry/lockfile noise
+   until the candidate is final.
+3. Run POC checks and build.
+4. Exercise localized Product, Collection, and Custom routes in Studio.
+5. Change a real product and collection resource on the smoke section.
+6. Inspect the revalidation response/visible QA snapshot for exact pathname,
+   locale, page type/handle, and ordinary query params.
+7. Confirm no page remount, scroll reset, stale draft, secret-bearing body field,
+   or unexpected full-route refresh.
+8. Remove the endpoint temporarily or mock a non-OK response and confirm Builder
+   still falls back to route refresh.
+
+## Guardrails
+
+- Do not read route identity from `window.location`.
+- Do not let Builder construct or pass route context.
+- Do not serialize `Headers`, `URL`, cookies, auth state, env, project ID, Studio
+  host, API key, API base, commerce client, or the whole runtime/client.
+- Do not trust `queries`; derive query values from sanitized `search` so there is
+  one canonical representation.
+- Do not change the endpoint default or Builder RPC signature.
+- Do not weaken registered-component lookup, no-store responses, or failure
+  fallback.
+- Do not publish until packed-tarball POC and manual Studio checks pass.
+
+## Expected deliverables
+
+- SDK implementation and regression tests
+- Package documentation update
+- POC integration and context-aware real-data smoke evidence
+- Updated spec work log with command outputs and manual QA result
+- Alpha release only after review and explicit approval

--- a/.specs/2026-07-22--next-route-context-revalidation/implementation-handoff.md
+++ b/.specs/2026-07-22--next-route-context-revalidation/implementation-handoff.md
@@ -19,6 +19,9 @@ the expected failure, then make the minimum implementation pass.
   `WeaverseNextRequestContext`, and passes it to the consumer factory.
 - Registered component loaders receive a client whose `requestContext` matches
   the active storefront route.
+- `pageType` is a `PageTypeSchema`-validated `PageType`, not an arbitrary string.
+- Duplicate Studio controls use the last value, and pathname/URL pathname share
+  one URL-canonicalized value.
 - Browser input cannot choose project ID, Weaverse host, API base, API key, or
   server env.
 - In-place loader application, fallback behavior, and scroll continuity remain
@@ -30,7 +33,8 @@ the expected failure, then make the minimum implementation pass.
 
 1. Add failing tests showing `buildWeaverseNextRequestInfo()` preserves optional
    `pageType` and `handle` from `WeaverseNextRequestContext`.
-2. Add the two optional fields to `WeaverseNextRequestInfo` and its builder.
+2. Add `pageType?: PageType` and `handle?: string` to
+   `WeaverseNextRequestInfo` and its builder.
 3. Run the focused request-info/runtime tests.
 
 ### 2. Client route-context serialization
@@ -49,17 +53,23 @@ the expected failure, then make the minimum implementation pass.
 1. Add failing tests for a valid localized PDP context.
 2. Extend `getClient` with an optional second `requestContext` argument.
 3. Validate and sanitize `routeContext` before client creation.
-4. Reconstruct pathname, `URLSearchParams`, same-origin URL, i18n, page type,
-   handle, and mode flags.
+4. Validate page type with `PageTypeSchema`; reconstruct canonical pathname,
+   `URLSearchParams`, same-origin URL, i18n, handle, and mode flags.
 5. Prove the registered loader receives that reconstructed context through the
    returned client's `requestContext`.
-6. Add hostile path/search/control-param tests and legacy missing-context test.
+6. Add literal/encoded dot-segment tests proving `pathname === url.pathname`.
+7. Add duplicate Studio-control tests proving last-value and cache-mode parity
+   with `getWeaverseNextConfigs()`.
+8. Add hostile path/search/control-param tests and legacy missing-context test.
 
 ### 4. POC route factory
 
 1. Refactor the POC server-client helper so page routes can pass `pageType` and
    `handle`, and the revalidation route can pass an explicit request context.
-2. Update Product, Collection, Index, and Custom load boundaries as appropriate.
+2. Update `app/[locale]/page.tsx`, Product
+   `app/[locale]/products/[handle]/page.tsx`, Collection
+   `app/[locale]/collections/[handle]/page.tsx`, and Custom
+   `app/[locale]/[...slug]/page.tsx`.
 3. Update the client wrapper to restore `pageType` and `handle` from serialized
    `configs.requestInfo`.
 4. Wire the revalidation handler callback's second argument into the explicit
@@ -67,6 +77,9 @@ the expected failure, then make the minimum implementation pass.
 5. Extend the existing real Storefront API smoke loader response with a compact
    route-context snapshot used only as QA evidence; do not replace Shopify data
    with fixtures or fallback demo data.
+6. Add `app/weaverse-next/revalidation-context.test.ts`; require assertions for
+   Product/Collection/Custom identity, explicit callback context, and legacy
+   missing-context fallback. The existing `npm test` glob runs this file.
 
 ### 5. Documentation and compatibility
 
@@ -74,7 +87,9 @@ the expected failure, then make the minimum implementation pass.
 2. Document that `requestContext` is validated browser input and project/host/env
    must still come from server config.
 3. Keep the old one-argument `getClient` callback example valid.
-4. Run package tests, typecheck, build, and formatting/lint checks.
+4. Run package tests, typecheck, build, and formatting/lint checks. Use
+   `pnpm exec biome check packages/next/src packages/next/__tests__
+   --diagnostic-level=error` from the SDK root.
 
 ### 6. Packed consumer and Studio QA
 
@@ -99,7 +114,12 @@ the expected failure, then make the minimum implementation pass.
   host, API key, API base, commerce client, or the whole runtime/client.
 - Do not trust `queries`; derive query values from sanitized `search` so there is
   one canonical representation.
+- Do not use `URLSearchParams.get()` for Studio controls; preserve current
+  last-duplicate precedence.
+- Do not retain raw pathname after URL canonicalization; context pathname and URL
+  pathname must be identical.
 - Do not change the endpoint default or Builder RPC signature.
+- Do not change Builder source for this slice.
 - Do not weaken registered-component lookup, no-store responses, or failure
   fallback.
 - Do not publish until packed-tarball POC and manual Studio checks pass.
@@ -108,6 +128,7 @@ the expected failure, then make the minimum implementation pass.
 
 - SDK implementation and regression tests
 - Package documentation update
-- POC integration and context-aware real-data smoke evidence
+- POC integration, automated route-context regressions, and real-data smoke
+  evidence
 - Updated spec work log with command outputs and manual QA result
 - Alpha release only after review and explicit approval

--- a/.specs/2026-07-22--next-route-context-revalidation/plan.md
+++ b/.specs/2026-07-22--next-route-context-revalidation/plan.md
@@ -1,0 +1,498 @@
+# Plan: Preserve route context during Next per-item revalidation
+
+## Problem
+
+`@weaverse/next` revalidates a loader-backed Studio item through a dedicated POST:
+
+```text
+Builder revalidate(id)
+  → runtime.internal.revalidateItem(draftItem)
+  → POST /api/weaverse/revalidate { draftItem }
+  → create app server client
+  → run registered component loader
+  → return loaderData
+  → apply loaderData to the existing item instance
+```
+
+The in-place update is correct: it avoids `router.refresh()`, RSC tree remounts,
+scroll reset, and client-state loss. The server request context is not correct.
+The POST contains no original route identity, and the handler's `Request` points
+to `/api/weaverse/revalidate`, not the page in the Studio iframe.
+
+The current POC mounts the handler as:
+
+```ts
+createWeaverseNextRevalidateHandler({
+  getClient: () => getWeaverseServerClient(Promise.resolve({})),
+})
+```
+
+That client falls back to pathname `/`, empty search, and no locale. The existing
+resource-picker smoke still passes because its loader only reads the selected
+resource and `commerce.storefront`; it does not inspect pathname, locale, page
+type, handle, or search state. A successful in-place update is therefore not
+proof that production loaders see the same context on page load and revalidation.
+
+This matters for:
+
+- localized PDPs such as `/fr-fr/products/classic-kicks`;
+- localized collection pages;
+- custom pages resolved by pathname;
+- loaders that branch on market/i18n;
+- loaders that read filters, variants, preview flags, or other search params;
+- loaders that use `context.pageType` or `context.handle`.
+
+## Evidence in current source
+
+- `packages/next/src/revalidate-item.ts` serializes only `{ draftItem }`.
+- `packages/next/src/server/revalidate-handler.ts` calls
+  `config.getClient(request)` and passes `client.requestContext` to the loader.
+- The endpoint request cannot reveal the owning storefront route.
+- `WeaverseNextRuntime` already owns `requestInfo`, a stable route snapshot used
+  in its runtime key and refreshed on pathname/search/locale navigation.
+- `getWeaverseNextConfigs()` reads `weaverseProjectId`, `weaverseHost`, and
+  `weaverseApiKey` from search params. Forwarding raw client search would let an
+  untrusted POST influence server-owned config.
+
+## Goals
+
+- Run a revalidated component loader with the same route identity as its active
+  page: pathname, ordinary search params, i18n, page type, and handle.
+- Preserve the existing in-place update and Builder fallback behavior.
+- Keep route-context capture SDK-owned; Builder continues to pass only the draft
+  item.
+- Keep the wire payload small, JSON-safe, explicit, and version-tolerant.
+- Keep project ID, Studio host, API base, API key, env, headers/cookies, and
+  commerce objects out of the browser-provided route envelope.
+- Give the consumer app an already validated `WeaverseNextRequestContext` from
+  which it can create the same server client/commerce context used by page loads.
+- Verify the contract against real localized Shopify Product, Collection, and
+  Custom routes in the POC.
+
+## Non-goals
+
+- Changing Builder's `internal.revalidateItem(draftItem)` contract.
+- Replacing full-page refresh flows or the older-SDK fallback.
+- Authenticating Studio or introducing a write-capable endpoint.
+- Sending a full `Request`, `Headers`, runtime, client, commerce object, or env
+  through JSON.
+- Letting the browser select a Weaverse project or API host.
+- Refactoring unrelated loader APIs, global sections, analytics, or page routing.
+- Solving every concurrent revalidation race; existing sequencing/fallback stays
+  unchanged unless a failing regression test proves this change introduces one.
+
+## Decision summary
+
+1. Extend the serialized runtime request info with optional `pageType` and
+   `handle`, which already exist on `WeaverseNextRequestContext`.
+2. POST a new optional `routeContext` field beside `draftItem`.
+3. Build it from the active runtime's `requestInfo`, never `window.location`.
+4. Serialize only pathname, sanitized search, narrow i18n, page type, and handle.
+5. Sanitize once before sending and again inside the route handler.
+6. Reconstruct a `WeaverseNextRequestContext` on the endpoint's own origin.
+7. Pass that as an optional second argument to `getClient`.
+8. Allow missing context so old clients/consumer callbacks remain operational.
+
+## Target data flow
+
+```text
+Server page request
+  → app builds WeaverseNextRequestContext
+      pathname=/fr-fr/products/classic-kicks
+      searchParams=?variant=123&isDesignMode=true
+      i18n={ country: FR, language: FR, locale: fr-FR }
+      pageType=PRODUCT
+      handle=classic-kicks
+  → server client returns configs.requestInfo
+  → client wrapper restores requestContext
+  → WeaverseNextRuntime.requestInfo owns the active sanitized route snapshot
+
+Studio resource edit
+  → Builder calls runtime.internal.revalidateItem(draftItem)       (unchanged)
+  → SDK snapshots runtime.requestInfo
+  → SDK strips server-owned/transient controls
+  → POST { draftItem, routeContext }
+  → handler validates and sanitizes routeContext again
+  → handler reconstructs WeaverseNextRequestContext on same origin
+  → config.getClient(apiRequest, reconstructedContext)
+  → client is created with server-owned project/env/host + route-owned context
+  → registered component loader receives client.requestContext
+  → loaderData response is applied to the existing item instance
+```
+
+## Public contract
+
+### Serialized route context
+
+Add a public JSON-safe type close to `revalidate-item.ts` and export it from the
+root entrypoint:
+
+```ts
+export interface WeaverseNextRevalidateRouteContext {
+  handle?: string
+  i18n?: Pick<
+    WeaverseNextI18n,
+    'country' | 'label' | 'language' | 'locale' | 'pathPrefix'
+  >
+  pageType?: PageType | string
+  pathname: string
+  search: string
+}
+```
+
+`search` is canonical; do not send the derived `queries` record. This avoids two
+representations disagreeing and preserves duplicate query keys through
+`URLSearchParams`.
+
+Extend `WeaverseNextRequestInfo`:
+
+```ts
+export interface WeaverseNextRequestInfo {
+  handle?: string
+  i18n?: WeaverseNextI18n
+  pageType?: PageType | string
+  pathname: string
+  queries: Record<string, string | boolean>
+  search: string
+}
+```
+
+`buildWeaverseNextRequestInfo(context)` copies `context.handle` and
+`context.pageType` when present. Existing callers remain valid because both are
+optional.
+
+### POST body
+
+```ts
+export interface WeaverseNextRevalidateRequestBody {
+  draftItem: WeaverseNextComponentData
+  routeContext?: WeaverseNextRevalidateRouteContext
+}
+```
+
+Example after sanitization:
+
+```json
+{
+  "draftItem": {
+    "id": "resource-section",
+    "type": "resource-picker-smoke",
+    "data": { "product": { "handle": "classic-kicks" } }
+  },
+  "routeContext": {
+    "pathname": "/fr-fr/products/classic-kicks",
+    "search": "?variant=123&isDesignMode=true",
+    "i18n": {
+      "country": "FR",
+      "language": "FR",
+      "locale": "fr-FR",
+      "pathPrefix": "/fr-fr"
+    },
+    "pageType": "PRODUCT",
+    "handle": "classic-kicks"
+  }
+}
+```
+
+### Client runtime surface
+
+Keep Builder's public capability unchanged:
+
+```ts
+runtime.internal.revalidateItem?: (
+  draftItem: WeaverseNextComponentData
+) => Promise<void>
+```
+
+Extend the structural helper surface without breaking manual mocks:
+
+```ts
+export interface RevalidateItemRuntimeLike {
+  itemInstances: Map<string, { setData(update: Record<string, unknown>): unknown }>
+  requestInfo?: WeaverseNextRequestInfo
+}
+```
+
+`requestInfo` stays optional. A real `WeaverseNextRuntime` always supplies it.
+When absent, the client omits `routeContext`, preserving the legacy request.
+
+### Handler factory
+
+Add an optional second callback argument:
+
+```ts
+export interface WeaverseNextRevalidateHandlerConfig {
+  getClient: (
+    request: Request,
+    requestContext?: WeaverseNextRequestContext
+  ) => Promise<WeaverseNextServerClient> | WeaverseNextServerClient
+}
+```
+
+A callback declared as `(request) => client` remains valid. New consumers use:
+
+```ts
+export const { POST } = createWeaverseNextRevalidateHandler({
+  getClient: (_request, requestContext) =>
+    getWeaverseServerClientFromContext(requestContext),
+})
+```
+
+The second argument is optional because an old SDK client may call a newly
+mounted handler without `routeContext`.
+
+## Route-context source of truth
+
+Use `runtime.requestInfo` captured at the start of
+`revalidateWeaverseNextItem()`. Do not use:
+
+- `window.location`: it introduces a second router source, complicates tests and
+  can disagree with the runtime during App Router transitions;
+- Builder's RPC payload: Builder should remain framework-neutral;
+- `runtime.internal.pageAssignment`: an inherited/default template handle may be
+  `*` or template metadata, not the actual Shopify resource route handle;
+- endpoint headers/pathname: they describe `/api/weaverse/revalidate`.
+
+The page route must put actual `pageType` and `handle` into its initial
+`WeaverseNextRequestContext`. The server payload, client wrapper, and runtime then
+carry one consistent route identity.
+
+## Client-side sanitization
+
+Create one focused helper, e.g. `buildWeaverseNextRevalidateRouteContext()`, that
+returns `undefined` without runtime request info and otherwise:
+
+- copies a valid pathname;
+- parses and re-serializes `search` with `URLSearchParams`;
+- copies only known i18n string fields;
+- copies bounded string `pageType` and `handle`;
+- removes denied query controls case-insensitively.
+
+Denied server-owned controls:
+
+- `weaverseProjectId`
+- `weaverseHost`
+- `weaverseApiKey`
+- `weaverseApiBase`
+- `weaversePublicApiBase`
+- `weaverseVersion`
+- `projectId`
+
+Denied transient transport/framework controls:
+
+- `weaverseDraftItem`
+- `__weaverseDraftItem`
+- `_rsc`
+
+Preserve ordinary application query parameters, duplicate keys, encoded Unicode,
+and these mode controls because they affect loader/cache semantics:
+
+- `isDesignMode`
+- `isPreviewMode`
+- `__revisionId`
+- `sectionType`
+
+Client sanitization keeps normal traffic clean; it is not the security boundary.
+
+## Handler validation and security boundary
+
+The route handler treats every body field as attacker-controlled. It repeats the
+client deny-list, validates strict route-field shapes and bounds, fixes the URL to
+the endpoint origin before assigning pathname/search, and rejects malformed
+present context with `400 { "error": "invalid-route-context" }` before client
+creation. Missing context remains valid legacy input.
+
+Only pathname, sanitized search, narrow i18n, page type, and handle cross the JSON
+boundary. Project ID, Studio host, API bases/keys, version controls, env, headers,
+cookies, commerce objects, runtime, and client stay out of the body. Actual POST
+headers may be attached server-side to the reconstructed context, but explicit
+route fields remain authoritative over API-route proxy headers.
+
+The complete normative deny-list, bounds, same-origin URL algorithm,
+reconstructed mode flags, consumer responsibilities, and adversarial tests live
+in [`security-contract.md`](./security-contract.md).
+
+## Handler behavior
+
+1. Parse JSON.
+2. Validate `draftItem` as today.
+3. If `routeContext` is present, validate and sanitize it.
+4. Reconstruct `WeaverseNextRequestContext`.
+5. Call `getClient(request, requestContext)`; pass `undefined` for legacy bodies.
+6. Resolve the registered component and loader as today.
+7. Run the loader with schema defaults, draft data, client, commerce, and
+   `client.requestContext`.
+8. Return `{ loaderData }` with no-store.
+9. Preserve existing status/error behavior; add only
+   `invalid-route-context` for malformed present context.
+
+## POC integration
+
+Refactor `app/weaverse-next/server.ts` around one lower-level client constructor
+that accepts an explicit `WeaverseNextRequestContext`. Normal page helpers still
+collect Next `headers()`/`searchParams`; the revalidation route passes the SDK's
+validated callback context and must not rediscover pathname/locale from API-route
+proxy headers.
+
+Page boundaries supply actual route identity: Index uses `INDEX`; Product and
+Collection use their real handles; Custom uses `CUSTOM` with exact pathname. The
+client wrapper restores page type/handle from `configs.requestInfo`, and the
+endpoint wires `getClient: (_request, context) =>
+getWeaverseServerClientFromContext(context)`.
+
+Keep the existing resource-picker smoke because it queries real Shopify data.
+Add a compact loader context snapshot as QA evidence rather than replacing the
+commerce query with fixtures. The exact POC edit order is in
+[`implementation-handoff.md`](./implementation-handoff.md).
+
+## Backward compatibility
+
+| Client | Handler/app | Result |
+| --- | --- | --- |
+| Old client | Old handler/app | Existing behavior |
+| Old client | New handler/app | No `routeContext`; handler passes `undefined`; consumer legacy fallback works |
+| New client | Old handler/app | Extra JSON field is ignored by the existing parser; existing behavior |
+| New client | New handler/app | Route-aware loader context |
+| Any client | New handler with an existing one-argument `getClient` callback | Callback ignores the optional second argument and still typechecks/runs |
+
+Builder requires no change because the SDK-bound function still accepts only
+`draftItem`.
+
+This is an additive alpha contract. Do not remove the missing-context path until
+a future major version and only with adoption evidence.
+
+## Exact SDK files
+
+- `packages/next/src/types.ts`
+  - add optional `pageType`/`handle` to `WeaverseNextRequestInfo` if not already
+    represented at implementation time;
+  - keep server request-context fields unchanged.
+- `packages/next/src/request-info.ts`
+  - serialize page type and handle.
+- `packages/next/src/revalidate-item.ts`
+  - define/export route-context type/helper;
+  - extend structural runtime surface;
+  - send sanitized context.
+- `packages/next/src/server/revalidate-handler.ts`
+  - extend body/config types;
+  - validate/sanitize/reconstruct route context;
+  - pass second factory argument.
+- `packages/next/src/index.ts` and `packages/next/src/server.ts`
+  - export the new public types/helpers from appropriate entrypoints.
+- `packages/next/__tests__/revalidate-item.test.ts`
+  - client and handler contract regression tests.
+- `packages/next/__tests__/next-adapter.test.tsx`
+  - request-info route identity tests.
+- `packages/next/README.md`
+  - route wiring, trust boundary, and migration example.
+
+No Builder source file should change for this slice.
+
+## POC files
+
+Expected integration surface in `Weaverse/weaverse-hydrogen-next-poc`:
+
+- `app/weaverse-next/server.ts`
+- `app/weaverse-next/wrapper.tsx`
+- `app/weaverse-next/server-components.ts`
+- `app/weaverse-next/components.tsx` only if a design-mode QA snapshot is rendered
+- `app/api/weaverse/revalidate/route.ts`
+- Product/Collection/Index/Custom page load boundaries that construct clients
+- focused tests for server-client context construction if the POC test harness
+  supports them
+
+Use the existing resource-picker smoke component because it queries real Shopify
+Storefront API product/collection data. Extend its loader result with a compact
+context snapshot for verification rather than replacing it with fixtures.
+
+## Verification
+
+The ordered TDD workflow and packed-consumer checklist are normative in
+[`implementation-handoff.md`](./implementation-handoff.md). At minimum, verify:
+
+- request info preserves optional page type/handle;
+- the client keeps localized route state and ordinary queries while removing all
+  denied controls;
+- the handler reconstructs a same-origin request context and preserves legacy
+  missing-context behavior;
+- loader data still applies in place and non-OK responses still trigger fallback;
+- package test/typecheck/build/Biome gates pass;
+- the exact packed candidate passes the POC build;
+- localized Product, Collection, and Custom Studio resource edits return real
+  Shopify data with exact context and no remount, scroll reset, stale draft, or
+  secret-bearing body fields.
+
+Expected SDK commands, adjusted only if package scripts changed:
+
+```bash
+pnpm --filter @weaverse/next test
+pnpm --filter @weaverse/next typecheck
+pnpm --filter @weaverse/next build
+pnpm biome check packages/next/src packages/next/__tests__
+```
+
+Do not claim consumer parity from SDK unit tests alone.
+
+## Release and rollout
+
+1. Merge SDK implementation only after package gates, independent review, packed
+   POC build, and manual local Studio smoke.
+2. Publish the next `0.1.0-alpha.*` only with explicit release approval.
+3. Bump the POC from tarball to the published exact version.
+4. Deploy POC manually and repeat Product/Collection/Custom Studio smoke.
+5. Record evidence in this spec's work log and #2737.
+6. Close #2737 only after production verification; then continue #2739 QA.
+
+## Risks and mitigations
+
+### Client-controlled context
+
+The endpoint is public and the route context is forgeable. Mitigation: narrow
+shape, bounds, same-origin URL reconstruction, double sanitization, server-owned
+project/host/credentials, registered loaders only, and no-store responses.
+
+### Consumer factory ignores the second argument
+
+The package cannot force an app to use context. Mitigation: update docs and real
+POC, make the callback explicit, and add a POC regression test/smoke. Keeping the
+argument optional preserves migration but production readiness requires using it.
+
+### Route context drifts during navigation
+
+Snapshot context at revalidation start. Runtime route keys/rebinding already
+track pathname/search changes. If a route changes while the request is in flight,
+the existing instance reference/fallback semantics remain; do not silently read
+later `window.location` state.
+
+### Search params influence server behavior
+
+Some mode params are intentionally preserved. Project, host, API key/base, and
+version controls are denied twice. Ordinary app params remain because loaders may
+legitimately depend on them.
+
+### Proxy headers describe the API endpoint
+
+The reconstructed context carries explicit route fields. POC factory code must
+not let API-route pathname/locale headers override them.
+
+## Rejected alternatives
+
+- Custom pathname header: insufficient for locale, search, and route identity.
+- `window.location`: a second route source that can race App Router transitions.
+- Builder-supplied context: leaks framework concerns into Builder.
+- Complete `requestInfo`: duplicates `search`/`queries` and carries denied controls.
+- Full request context/runtime/client: not JSON-safe and risks secret leakage.
+- Handler pathname parsing: route conventions are app-owned; page boundaries
+  already know page type and actual handle.
+
+## Completion gate
+
+This work is complete only when:
+- SDK route identity is propagated and validated end to end;
+- security-sensitive controls cannot reach client construction from the body;
+- old callback/body shapes remain covered;
+- package checks and independent review pass;
+- the packed package works in the real POC;
+- localized Product, Collection, and Custom resource edits pass in Studio with
+  real Shopify data and no visual continuity regression;
+- the deployed exact package version is rechecked and evidence is logged.

--- a/.specs/2026-07-22--next-route-context-revalidation/plan.md
+++ b/.specs/2026-07-22--next-route-context-revalidation/plan.md
@@ -134,7 +134,7 @@ export interface WeaverseNextRevalidateRouteContext {
     WeaverseNextI18n,
     'country' | 'label' | 'language' | 'locale' | 'pathPrefix'
   >
-  pageType?: PageType | string
+  pageType?: PageType
   pathname: string
   search: string
 }
@@ -150,7 +150,7 @@ Extend `WeaverseNextRequestInfo`:
 export interface WeaverseNextRequestInfo {
   handle?: string
   i18n?: WeaverseNextI18n
-  pageType?: PageType | string
+  pageType?: PageType
   pathname: string
   queries: Record<string, string | boolean>
   search: string
@@ -265,7 +265,8 @@ returns `undefined` without runtime request info and otherwise:
 - copies a valid pathname;
 - parses and re-serializes `search` with `URLSearchParams`;
 - copies only known i18n string fields;
-- copies bounded string `pageType` and `handle`;
+- copies `pageType` only when `PageTypeSchema` accepts it and copies a bounded
+  string `handle`;
 - removes denied query controls case-insensitively.
 
 Denied server-owned controls:
@@ -296,11 +297,10 @@ Client sanitization keeps normal traffic clean; it is not the security boundary.
 
 ## Handler validation and security boundary
 
-The route handler treats every body field as attacker-controlled. It repeats the
-client deny-list, validates strict route-field shapes and bounds, fixes the URL to
-the endpoint origin before assigning pathname/search, and rejects malformed
-present context with `400 { "error": "invalid-route-context" }` before client
-creation. Missing context remains valid legacy input.
+The route handler repeats the client deny-list, validates `PageTypeSchema`, fixes
+the URL origin, canonicalizes both pathname identities once, and uses last-value
+Studio-control semantics. Malformed present context returns
+`400 { "error": "invalid-route-context" }`; missing context stays legacy-valid.
 
 Only pathname, sanitized search, narrow i18n, page type, and handle cross the JSON
 boundary. Project ID, Studio host, API bases/keys, version controls, env, headers,
@@ -364,8 +364,8 @@ a future major version and only with adoption evidence.
 ## Exact SDK files
 
 - `packages/next/src/types.ts`
-  - add optional `pageType`/`handle` to `WeaverseNextRequestInfo` if not already
-    represented at implementation time;
+  - add optional `pageType: PageType`/`handle` to `WeaverseNextRequestInfo` if
+    not already represented at implementation time;
   - keep server request-context fields unchanged.
 - `packages/next/src/request-info.ts`
   - serialize page type and handle.
@@ -386,20 +386,18 @@ a future major version and only with adoption evidence.
 - `packages/next/README.md`
   - route wiring, trust boundary, and migration example.
 
-No Builder source file should change for this slice.
-
 ## POC files
 
 Expected integration surface in `Weaverse/weaverse-hydrogen-next-poc`:
 
-- `app/weaverse-next/server.ts`
-- `app/weaverse-next/wrapper.tsx`
-- `app/weaverse-next/server-components.ts`
+- `app/weaverse-next/server.ts`, `wrapper.tsx`, `server-components.ts`
+- `app/weaverse-next/revalidation-context.test.ts` (new; matched by `npm test`)
 - `app/weaverse-next/components.tsx` only if a design-mode QA snapshot is rendered
 - `app/api/weaverse/revalidate/route.ts`
-- Product/Collection/Index/Custom page load boundaries that construct clients
-- focused tests for server-client context construction if the POC test harness
-  supports them
+- route boundaries: `app/[locale]/page.tsx`, plus `products/[handle]/page.tsx`,
+  `collections/[handle]/page.tsx`, and `[...slug]/page.tsx` under `app/[locale]/`
+
+The POC test covers Product/Collection/Custom identity, callback wiring, and legacy fallback.
 
 Use the existing resource-picker smoke component because it queries real Shopify
 Storefront API product/collection data. Extend its loader result with a compact
@@ -415,6 +413,8 @@ The ordered TDD workflow and packed-consumer checklist are normative in
   denied controls;
 - the handler reconstructs a same-origin request context and preserves legacy
   missing-context behavior;
+- duplicate Studio controls use the last value/cache path, while literal/encoded
+  dot segments produce one canonical pathname in both context fields;
 - loader data still applies in place and non-OK responses still trigger fallback;
 - package test/typecheck/build/Biome gates pass;
 - the exact packed candidate passes the POC build;
@@ -428,7 +428,7 @@ Expected SDK commands, adjusted only if package scripts changed:
 pnpm --filter @weaverse/next test
 pnpm --filter @weaverse/next typecheck
 pnpm --filter @weaverse/next build
-pnpm biome check packages/next/src packages/next/__tests__
+pnpm exec biome check packages/next/src packages/next/__tests__ --diagnostic-level=error
 ```
 
 Do not claim consumer parity from SDK unit tests alone.

--- a/.specs/2026-07-22--next-route-context-revalidation/security-contract.md
+++ b/.specs/2026-07-22--next-route-context-revalidation/security-contract.md
@@ -15,7 +15,7 @@ export interface WeaverseNextRevalidateRouteContext {
     WeaverseNextI18n,
     'country' | 'label' | 'language' | 'locale' | 'pathPrefix'
   >
-  pageType?: PageType | string
+  pageType?: PageType
   pathname: string
   search: string
 }
@@ -55,7 +55,8 @@ semantics: `isDesignMode`, `isPreviewMode`, `__revisionId`, and `sectionType`.
 - `pathname`: non-empty string, maximum 2,048 characters.
 - `search`: string, empty or begins with `?`, maximum 8,192 characters.
 - `handle`: optional non-empty string, maximum 512 characters.
-- `pageType`: optional non-empty string, maximum 64 characters.
+- `pageType`: optional value accepted by `PageTypeSchema`; arbitrary strings are
+  invalid.
 - Each allowed i18n field: optional string, maximum 256 characters.
 - `i18n`: plain object only; arrays and nested values are invalid.
 
@@ -73,37 +74,50 @@ A valid pathname:
 - contains no `?` or `#`.
 
 Never resolve an untrusted pathname with `new URL(pathname, origin)`. Fix the
-endpoint origin first, then assign validated components:
+endpoint origin first, then assign validated components and reuse the URL's
+canonical pathname everywhere:
 
 ```ts
 let endpointUrl = new URL(request.url)
 let routeUrl = new URL(endpointUrl.origin)
 routeUrl.pathname = pathname
 routeUrl.search = sanitizedSearch
+let canonicalPathname = routeUrl.pathname
 ```
 
 Browser input therefore cannot change protocol, host, port, username, or
-password.
+password. Literal or percent-encoded dot segments may normalize, but
+`requestContext.pathname` and `requestContext.url.pathname` must both receive
+`canonicalPathname`; never preserve the raw pathname in only one field.
 
 ## Reconstructed server context
 
 The handler creates:
 
 ```ts
+let lastParam = (key: string) => {
+  let values = searchParams.getAll(key)
+  return values.length ? values.at(-1) : undefined
+}
+
 let requestContext: WeaverseNextRequestContext = {
-  pathname,
+  pathname: canonicalPathname,
   searchParams,
   url: routeUrl,
   headers: new Headers(request.headers),
   i18n,
   pageType,
   handle,
-  isDesignMode: searchParams.get('isDesignMode') === 'true',
-  isPreviewMode: searchParams.get('isPreviewMode') === 'true',
+  isDesignMode: lastParam('isDesignMode') === 'true',
+  isPreviewMode: lastParam('isPreviewMode') === 'true',
   isRevisionPreview: searchParams.has('__revisionId'),
-  sectionType: searchParams.get('sectionType') || undefined,
+  sectionType: lastParam('sectionType') || undefined,
 }
 ```
+
+Last-value semantics are normative for duplicated Studio controls because Studio
+appends its authoritative values. This must match `getWeaverseNextConfigs()` and
+its cache-mode resolution.
 
 Headers come from the actual same-origin POST, never its JSON body. Apps must
 treat explicit pathname/search/i18n as authoritative because proxy route headers
@@ -133,11 +147,15 @@ Existing endpoint protections remain mandatory:
 ## Required adversarial tests
 
 - Absolute/protocol-relative pathname cannot change origin.
+- Literal and percent-encoded dot segments yield the same canonical value in
+  `pathname` and `url.pathname`.
 - Backslash, control character, query-in-path, fragment-in-path, and oversized
   values fail before client construction.
-- Malformed i18n, page type, handle, and search fail closed.
+- Malformed i18n, `PageTypeSchema` values, handle, and search fail closed.
 - Every denied key is removed even when client-side sanitization is bypassed.
 - Duplicate ordinary queries and encoded Unicode survive.
+- Duplicate `isDesignMode`, `isPreviewMode`, and `sectionType` controls use the
+  last value; cache-mode assertions match normal config resolution.
 - JSON cannot invent headers/cookies.
 - Spoofed pathname/handle/page type is treated only as public routing input and
   cannot bypass a registered loader's independent customer/private-data auth.

--- a/.specs/2026-07-22--next-route-context-revalidation/security-contract.md
+++ b/.specs/2026-07-22--next-route-context-revalidation/security-contract.md
@@ -1,0 +1,145 @@
+# Security contract: revalidation route context
+
+The revalidation endpoint is public and every JSON field is attacker-controlled.
+Client-side sanitization keeps normal traffic clean; handler-side validation is
+the security boundary.
+
+## Wire shape
+
+Only this JSON-safe route subset may cross the browser boundary:
+
+```ts
+export interface WeaverseNextRevalidateRouteContext {
+  handle?: string
+  i18n?: Pick<
+    WeaverseNextI18n,
+    'country' | 'label' | 'language' | 'locale' | 'pathPrefix'
+  >
+  pageType?: PageType | string
+  pathname: string
+  search: string
+}
+```
+
+Never serialize headers, cookies, auth state, env, project ID, Studio host, API
+keys/bases, commerce clients, the complete request context, runtime, or client.
+Do not send the derived `queries` record; `search` is canonical and preserves
+duplicate keys.
+
+## Double sanitization
+
+Apply the same denied-query policy before sending and after parsing.
+
+Server-owned controls:
+
+- `weaverseProjectId`
+- `weaverseHost`
+- `weaverseApiKey`
+- `weaverseApiBase`
+- `weaversePublicApiBase`
+- `weaverseVersion`
+- `projectId`
+
+Transient transport/framework controls:
+
+- `weaverseDraftItem`
+- `__weaverseDraftItem`
+- `_rsc`
+
+Compare denied keys case-insensitively. Preserve ordinary application queries,
+duplicate keys, encoded Unicode, and the mode controls needed by loader/cache
+semantics: `isDesignMode`, `isPreviewMode`, `__revisionId`, and `sectionType`.
+
+## Shape and bounds
+
+- `pathname`: non-empty string, maximum 2,048 characters.
+- `search`: string, empty or begins with `?`, maximum 8,192 characters.
+- `handle`: optional non-empty string, maximum 512 characters.
+- `pageType`: optional non-empty string, maximum 64 characters.
+- Each allowed i18n field: optional string, maximum 256 characters.
+- `i18n`: plain object only; arrays and nested values are invalid.
+
+A malformed present context returns HTTP 400 with
+`{ "error": "invalid-route-context" }` before `getClient` runs. A completely
+missing context is valid legacy input and passes `undefined` to the callback.
+
+## Path and origin safety
+
+A valid pathname:
+
+- starts with exactly one `/`;
+- does not start with `//`;
+- contains no backslash or ASCII control character;
+- contains no `?` or `#`.
+
+Never resolve an untrusted pathname with `new URL(pathname, origin)`. Fix the
+endpoint origin first, then assign validated components:
+
+```ts
+let endpointUrl = new URL(request.url)
+let routeUrl = new URL(endpointUrl.origin)
+routeUrl.pathname = pathname
+routeUrl.search = sanitizedSearch
+```
+
+Browser input therefore cannot change protocol, host, port, username, or
+password.
+
+## Reconstructed server context
+
+The handler creates:
+
+```ts
+let requestContext: WeaverseNextRequestContext = {
+  pathname,
+  searchParams,
+  url: routeUrl,
+  headers: new Headers(request.headers),
+  i18n,
+  pageType,
+  handle,
+  isDesignMode: searchParams.get('isDesignMode') === 'true',
+  isPreviewMode: searchParams.get('isPreviewMode') === 'true',
+  isRevisionPreview: searchParams.has('__revisionId'),
+  sectionType: searchParams.get('sectionType') || undefined,
+}
+```
+
+Headers come from the actual same-origin POST, never its JSON body. Apps must
+treat explicit pathname/search/i18n as authoritative because proxy route headers
+on this request may describe `/api/weaverse/revalidate`.
+
+## Consumer responsibility
+
+The app creates its client with project ID, host, API bases/keys, environment,
+component registry, and cache policy from server code/config only. It may use the
+validated context for route identity, locale, request headers, and commerce
+market construction, but it must not recover denied controls from raw body data.
+
+Route context is routing input, never an authorization decision. A registered
+loader must not treat pathname, handle, page type, locale, or search values as
+proof that the caller may access a resource. Public Storefront lookups may use
+those values; customer/private data requires independent server-side session and
+authorization checks derived from the actual request.
+
+Existing endpoint protections remain mandatory:
+
+- execute only registered component types;
+- run loaders only and never persist draft data;
+- respond `Cache-Control: no-store` on success and errors;
+- reject non-OK responses client-side so Builder can fall back;
+- keep design/revision requests uncached.
+
+## Required adversarial tests
+
+- Absolute/protocol-relative pathname cannot change origin.
+- Backslash, control character, query-in-path, fragment-in-path, and oversized
+  values fail before client construction.
+- Malformed i18n, page type, handle, and search fail closed.
+- Every denied key is removed even when client-side sanitization is bypassed.
+- Duplicate ordinary queries and encoded Unicode survive.
+- JSON cannot invent headers/cookies.
+- Spoofed pathname/handle/page type is treated only as public routing input and
+  cannot bypass a registered loader's independent customer/private-data auth.
+- Missing context keeps legacy behavior.
+- Invalid context responses remain `no-store`.

--- a/.specs/2026-07-22--next-route-context-revalidation/work-logs.md
+++ b/.specs/2026-07-22--next-route-context-revalidation/work-logs.md
@@ -45,6 +45,10 @@ Spec-only branch. No package or POC implementation is included in this PR.
 - Frozen-diff scope/secret scan passed; all referenced SDK/POC paths and current
   contract assertions were checked against source.
 - Copilot autoreview was unavailable due quota exhaustion (HTTP 402).
-- Claude Code no-tools review found one SDD traceability blocker plus table/auth
-  clarifications; all were fixed. The second pass returned `APPROVE` with no
-  blockers.
+- Initial Claude Code no-tools review found one SDD traceability blocker plus
+  table/auth clarifications; all were fixed, then its second pass approved.
+- A later source-auditing subagent found five deeper blockers: duplicate-control
+  precedence, `PageType` validation, pathname canonicalization, mandatory POC
+  tests/exact routes, and an invalid Biome command. All five were corrected.
+- Targeted post-fix review returned `APPROVE` with no blockers. The corrected
+  Biome command checked 35 SDK files successfully.

--- a/.specs/2026-07-22--next-route-context-revalidation/work-logs.md
+++ b/.specs/2026-07-22--next-route-context-revalidation/work-logs.md
@@ -1,0 +1,50 @@
+# Work Logs
+
+## 2026-07-22 — @hta218
+
+### Investigation
+
+- Confirmed `revalidateWeaverseNextItem()` posts only `{ draftItem }`.
+- Confirmed `createWeaverseNextRevalidateHandler()` passes its own API-route
+  `Request` to `getClient()` and runs the loader with `client.requestContext`.
+- Confirmed the production POC callback ignores the endpoint request and creates
+  a client from empty search params, which falls back to pathname `/` and no
+  locale.
+- Confirmed the POC resource-picker smoke loader uses real Shopify Storefront API
+  data but does not inspect route context, so the existing successful smoke does
+  not prove context parity.
+- Confirmed the runtime already owns a stable, client-safe `requestInfo` snapshot
+  and recreates/rebinds it across pathname, search, and locale navigation.
+- Confirmed the server config resolver reads security-sensitive query controls:
+  `weaverseProjectId`, `weaverseHost`, and `weaverseApiKey`. Raw runtime search
+  must therefore not be forwarded without sanitization.
+
+### Decision
+
+- Carry a narrow `routeContext` beside `draftItem`.
+- Source it from the active runtime, not `window.location` or Builder RPC input.
+- Preserve pathname, ordinary search parameters, locale/i18n, page type, and
+  handle.
+- Strip project/host/API-key/API-base/version controls and transient draft/RSC
+  parameters on both sides of the trust boundary.
+- Reconstruct `WeaverseNextRequestContext` inside the SDK route handler and pass
+  it as an optional second argument to `getClient(request, requestContext)`.
+- Keep missing `routeContext` backward compatible for old clients.
+- Require no Builder contract change; `internal.revalidateItem(draftItem)` keeps
+  its current signature.
+
+### Output
+
+Spec-only branch. No package or POC implementation is included in this PR.
+
+### Spec review
+
+- Repository SDD validation passed: required files/metadata are present,
+  relative links resolve, branch naming is valid, and `plan.md` is under 500
+  lines.
+- Frozen-diff scope/secret scan passed; all referenced SDK/POC paths and current
+  contract assertions were checked against source.
+- Copilot autoreview was unavailable due quota exhaustion (HTTP 402).
+- Claude Code no-tools review found one SDD traceability blocker plus table/auth
+  clarifications; all were fixed. The second pass returned `APPROVE` with no
+  blockers.


### PR DESCRIPTION
## Summary

- document the route-context correctness gap in Next per-item Studio revalidation
- define the additive client payload and `getClient` callback contract
- specify double sanitization, same-origin reconstruction, and authorization boundaries
- provide an ordered TDD handoff, mandatory POC regression coverage, packed-package verification, and production Studio smoke matrix

## Scope

Spec-only PR. It does not change package, Builder, or POC runtime code.

## Validation

- repository SDD structure and metadata validated; `plan.md` is 498 lines
- relative links, source assertions, and referenced SDK/POC paths verified
- staged diff/secret/whitespace checks passed
- source-auditing independent review found five blockers; all were corrected
- targeted post-fix Claude Code no-tools review: APPROVE, no blockers
- corrected Biome command checked 35 SDK files successfully

Refs Weaverse/builder#2737
