### PR TITLE
Support function-based component availability

### DIFF
--- a/.specs/2026-07-23--function-based-component-availability/README.md
+++ b/.specs/2026-07-23--function-based-component-availability/README.md
@@ -1,0 +1,24 @@
+# Feature: Function-Based Component Availability
+
+| Field            | Value                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+| **Status**       | in-progress                                                                                             |
+| **Owner**        | @paul                                                                                                   |
+| **Issue**        | [builder#2736](https://github.com/Weaverse/builder/issues/2736)                                         |
+| **Branch**       | `feat/function-based-component-availability`                                                            |
+| **Created**      | 2026-07-23                                                                                              |
+| **Last Updated** | 2026-07-23                                                                                              |
+
+## Original Prompt
+
+> take a look and prepare a plan to implement https://github.com/Weaverse/builder/issues/2736
+>
+> also our docs, skills also need to update afterward
+>
+> /Users/paul/Workspace/shopify-hydrogen-skills
+>
+> ok let start
+
+## Summary
+
+Add the public schema types for synchronous, context-aware component availability while preserving `enabledOn`. Runtime callback evaluation remains in Builder's preview bridge; this repository supplies the validated SDK contract consumed by storefront themes and Builder.

--- a/.specs/2026-07-23--function-based-component-availability/plan.md
+++ b/.specs/2026-07-23--function-based-component-availability/plan.md
@@ -1,0 +1,61 @@
+# Implementation Plan
+
+## Scope
+
+Implement the public `enabled` component-schema API required by builder#2736:
+
+```ts
+enabled?: Resolvable<boolean, ComponentAvailabilityContext>
+```
+
+The callback receives the current page `{ id, type, handle, locale }` and placement `group`. Existing `enabledOn` remains supported and Builder combines both rules with AND semantics.
+
+Function forms for `childTypes`, `limit`, `presets`, and input `shouldRevalidate` are follow-up work; they require different per-instance contexts and are not part of this delivery.
+
+## Design
+
+1. Define and export `Resolvable`, `ComponentGroup`, and `ComponentAvailabilityContext` from `@weaverse/schema`.
+2. Add `enabled` to the canonical Zod element schema and duplicated strict/helper shapes.
+3. Development validation accepts booleans and functions without executing callbacks. Runtime synchronization and error handling belong to Builder's preview bridge.
+4. Add `SchemaBuilder.enabled()`. Existing object-spread behavior in `mergeSchemas` gives `enabled` last-override-wins semantics.
+5. Update Hydrogen's duplicated schema options type. `HydrogenComponentSchema` continues to alias `SchemaType` and Hydrogen continues re-exporting schema types.
+6. Do not resolve availability during component registration; the registry must retain the raw callback for the active preview bridge to evaluate against current page context.
+
+## Tests
+
+- Accept `enabled: true` and `enabled: false`.
+- Accept a synchronous callback and preserve its inferred context.
+- Reject invalid scalar values.
+- Verify `SchemaBuilder.enabled()` and `mergeSchemas()` preserve false/callback values.
+- Verify the types are exported through `@weaverse/hydrogen` declarations.
+- Preserve all existing schema validation behavior.
+
+## Validation
+
+```sh
+pnpm exec vp test --run packages/schema/test
+pnpm -F @weaverse/schema build
+pnpm -F @weaverse/hydrogen build
+pnpm run biome
+pnpm run typecheck
+```
+
+Before release, run the full monorepo test/build gates required by the SDK release skill.
+
+## Files and Folders Touched
+
+- `.specs/2026-07-23--function-based-component-availability/`
+- `packages/schema/src/validation.ts`
+- `packages/schema/src/index.ts`
+- `packages/schema/test/`
+- `packages/schema/README.md`
+- `packages/hydrogen/src/types.ts`
+- `packages/hydrogen/__tests__/` only if an emitted/re-export regression test is needed
+- package versions and `pnpm-lock.yaml` during the approved release step
+
+## Delivery Sequence
+
+1. Merge and release the independent schema package.
+2. Update Hydrogen's exact schema dependency and release the fixed core/react/hydrogen group.
+3. Builder consumes the released SDK and implements preview-side resolution.
+4. Public docs and `/Users/paul/Workspace/shopify-hydrogen-skills` update only after SDK and Builder behavior are released.

--- a/.specs/2026-07-23--function-based-component-availability/work-logs.md
+++ b/.specs/2026-07-23--function-based-component-availability/work-logs.md
@@ -1,0 +1,9 @@
+# Work Logs
+
+## 2026-07-23 — @paul
+
+- Created an isolated worktree from `origin/main` on `feat/function-based-component-availability`.
+- Added the public `Resolvable`, `ComponentGroup`, `ComponentAvailabilityContext`, and `enabled` schema contract using test-first development.
+- Updated strict schema helpers, `SchemaBuilder`, Hydrogen options typing, tests, and the schema package README.
+- Verified 11 focused tests, 38 schema tests, schema/Hydrogen builds, Biome, and monorepo typecheck.
+- Left package versions and lockfile unchanged pending explicit release approval. Hydrogen's exact schema dependency must be updated after the independent schema release.

--- a/packages/hydrogen/__tests__/component-availability-types.test.ts
+++ b/packages/hydrogen/__tests__/component-availability-types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type {
+  ComponentAvailabilityContext,
+  ComponentGroup,
+  CreateHydrogenSchemaOptions,
+  HydrogenComponentSchema,
+  Resolvable,
+} from '../src'
+
+describe('Hydrogen component availability types', () => {
+  it('should_export_component_availability_types', () => {
+    // Arrange
+    let enabled: Resolvable<boolean, ComponentAvailabilityContext> = ({
+      page,
+      group,
+    }) => page.handle === 'freebies/essential' && group === 'body'
+    let options: CreateHydrogenSchemaOptions = {
+      title: 'Availability Test',
+      type: 'availability-test',
+      enabled,
+    }
+    let schema: HydrogenComponentSchema = options
+
+    // Act
+    let schemaEnabled = schema.enabled
+
+    // Assert
+    expectTypeOf<ComponentGroup>().toEqualTypeOf<'body' | 'header' | 'footer'>()
+    expectTypeOf(schemaEnabled).toEqualTypeOf<
+      Resolvable<boolean, ComponentAvailabilityContext> | undefined
+    >()
+  })
+})

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -595,6 +595,17 @@ export type CreateHydrogenSchemaOptions = {
     pages?: PageType[]
     groups?: ('*' | 'header' | 'footer' | 'body')[]
   }
+  enabled?:
+    | boolean
+    | ((context: {
+        page: {
+          id: string
+          type: PageType
+          handle: string
+          locale: string
+        }
+        group: 'body' | 'header' | 'footer'
+      }) => boolean)
   presets?: {
     children?: SchemaComponentPresets[]
     [key: string]: any

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -66,6 +66,7 @@ export type ElementSchema = {
     pages?: ('*' | PageType)[]
     groups?: ('*' | 'header' | 'footer' | 'body')[]
   }
+  enabled?: Resolvable<boolean, ComponentAvailabilityContext>
   presets?: {
     children?: Array<{ type: string; [key: string]: any }>
     [key: string]: any
@@ -144,6 +145,30 @@ if (isValidSchema(data)) {
 }
 ```
 
+### Context-aware component availability
+
+Use `enabled` when availability depends on the current page or placement group:
+
+```typescript
+import { createSchema } from '@weaverse/schema'
+
+const schema = createSchema({
+  title: 'Freebies',
+  type: 'freebies',
+  enabledOn: {
+    pages: ['CUSTOM'],
+  },
+  enabled: ({ page, group }) =>
+    page.handle === 'freebies/essential' && group === 'body',
+})
+```
+
+`enabled` accepts a boolean or a synchronous callback. The callback receives
+`page` (`id`, `type`, `handle`, and `locale`) and `group` (`body`, `header`, or
+`footer`). When both `enabledOn` and `enabled` are set, both rules must pass.
+The SDK preserves callbacks without executing them; the Weaverse preview bridge
+evaluates them against its current page context.
+
 ### Schema Builder Pattern
 
 Create schemas fluently with the builder pattern:
@@ -175,6 +200,7 @@ const schema = schemaBuilder()
     pages: ['PRODUCT', 'COLLECTION'],
     groups: ['body']
   })
+  .enabled(({ group }) => group === 'body')
   .build()
 ```
 
@@ -328,7 +354,7 @@ All types are inferred from Zod schemas, ensuring:
 - Runtime validation matches TypeScript types
 - Single source of truth for type definitions
 - Automatic type generation from schema changes
-- Proper serialization support (no function types in schemas)
+- Context-aware component availability callbacks are preserved for preview-side evaluation
 
 ## Development
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,10 +1,12 @@
 import type {
   BasicInput,
+  ComponentAvailabilityContext,
   ComponentPresets,
   HeadingInput,
   InspectorGroup,
   PageType,
   RangeInputConfigs,
+  Resolvable,
   SchemaType,
   SchemaValidationIssue,
 } from './validation'
@@ -39,6 +41,7 @@ export type SchemaTypeStrict = {
     pages?: PageType[]
     groups?: ('*' | 'header' | 'footer' | 'body')[]
   }
+  enabled?: Resolvable<boolean, ComponentAvailabilityContext>
   presets?: {
     children?: ComponentPresets[]
     [key: string]: any
@@ -101,6 +104,7 @@ export function createSchemaTypeSafe(schema: {
     pages?: PageType[]
     groups?: ('*' | 'header' | 'footer' | 'body')[]
   }
+  enabled?: Resolvable<boolean, ComponentAvailabilityContext>
   presets?: {
     children?: ComponentPresets[]
     [key: string]: any
@@ -172,6 +176,11 @@ export class SchemaBuilder {
 
   enabledOn(enabledOn: SchemaType['enabledOn']): SchemaBuilder {
     this.schema.enabledOn = enabledOn
+    return this
+  }
+
+  enabled(enabled: SchemaType['enabled']): SchemaBuilder {
+    this.schema.enabled = enabled
     return this
   }
 
@@ -394,6 +403,8 @@ export const groupHelpers = {
 
 export type {
   BasicInput,
+  ComponentAvailabilityContext,
+  ComponentGroup,
   ComponentPresets,
   ComponentValidationOptions,
   ConfigsProps,
@@ -403,6 +414,7 @@ export type {
   InspectorGroup,
   PageType,
   RangeInputConfigs,
+  Resolvable,
   SchemaMigration,
   SchemaType,
   SchemaValidationFailure,

--- a/packages/schema/src/validation.ts
+++ b/packages/schema/src/validation.ts
@@ -184,6 +184,20 @@ export const PageTypeSchema = z.union([
   z.literal('CUSTOM'),
 ])
 
+export type Resolvable<T, Context> = T | ((context: Context) => T)
+
+export type ComponentGroup = 'body' | 'header' | 'footer'
+
+export interface ComponentAvailabilityContext {
+  group: ComponentGroup
+  page: {
+    id: string
+    type: PageType
+    handle: string
+    locale: string
+  }
+}
+
 export const ComponentPresetsSchema = z
   .object({
     type: z.string().describe('The type of the component'),
@@ -246,6 +260,13 @@ export const ElementSchema = z
       })
       .optional()
       .describe('Where this element can be enabled'),
+    enabled: z
+      .custom<Resolvable<boolean, ComponentAvailabilityContext>>(
+        (value) => typeof value === 'boolean' || typeof value === 'function',
+        'Enabled must be a boolean or synchronous function'
+      )
+      .optional()
+      .describe('Whether this element is available in the current context'),
     presets: z
       .object({
         children: z

--- a/packages/schema/test/component-availability.test.ts
+++ b/packages/schema/test/component-availability.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+import {
+  type ComponentAvailabilityContext,
+  type ComponentGroup,
+  createSchemaTypeSafe,
+  ElementSchema,
+  mergeSchemas,
+  type PageType,
+  type Resolvable,
+  SchemaRegistry,
+  type SchemaType,
+  type SchemaTypeStrict,
+  schemaBuilder,
+  validateSchema,
+} from '../src'
+
+describe('component availability', () => {
+  it.each([
+    true,
+    false,
+  ])('should_preserve_boolean_enabled_when_value_is_%s', (enabled) => {
+    // Arrange
+    let componentSchema = {
+      title: 'Availability Test',
+      type: 'availability-test',
+      enabled,
+    }
+
+    // Act
+    let result = validateSchema(componentSchema)
+
+    // Assert
+    expect(result.success && result.data.enabled).toBe(enabled)
+  })
+
+  it('should_preserve_callback_enabled_without_executing_it', () => {
+    // Arrange
+    let enabled = vi.fn(
+      ({ page, group }: ComponentAvailabilityContext) =>
+        page.type === 'CUSTOM' && group === 'body'
+    )
+    let componentSchema: SchemaType = {
+      title: 'Availability Test',
+      type: 'availability-test',
+      enabled,
+    }
+
+    // Act
+    let result = ElementSchema.safeParse(componentSchema)
+
+    // Assert
+    expect({
+      enabled: result.success ? result.data.enabled : undefined,
+      invocationCount: enabled.mock.calls.length,
+    }).toEqual({ enabled, invocationCount: 0 })
+  })
+
+  it('should_infer_the_documented_callback_context', () => {
+    // Arrange
+    let componentSchema: SchemaType = {
+      title: 'Availability Test',
+      type: 'availability-test',
+      enabled: ({ page, group }) => {
+        expectTypeOf(page).toEqualTypeOf<{
+          id: string
+          type: PageType
+          handle: string
+          locale: string
+        }>()
+        expectTypeOf(group).toEqualTypeOf<ComponentGroup>()
+        return page.handle === 'freebies/essential' && group === 'body'
+      },
+    }
+
+    // Act
+    let enabled = componentSchema.enabled
+
+    // Assert
+    expectTypeOf(enabled).toEqualTypeOf<
+      Resolvable<boolean, ComponentAvailabilityContext> | undefined
+    >()
+  })
+
+  it('should_reject_invalid_scalar_enabled', () => {
+    // Arrange
+    let componentSchema = {
+      title: 'Availability Test',
+      type: 'availability-test',
+      enabled: 'yes',
+    }
+
+    // Act
+    let result = validateSchema(componentSchema)
+
+    // Assert
+    expect(result.success).toBe(false)
+  })
+
+  it.each([
+    false,
+    ({ page }: ComponentAvailabilityContext) => page.type === 'CUSTOM',
+  ])('should_preserve_enabled_from_schema_builder', (enabled) => {
+    // Arrange
+    let builder = schemaBuilder()
+      .title('Availability Test')
+      .type('availability-test')
+
+    // Act
+    let componentSchema = builder.enabled(enabled).buildUnsafe()
+
+    // Assert
+    expect(componentSchema.enabled).toBe(enabled)
+  })
+
+  it('should_support_enabled_in_strict_schema_helpers', () => {
+    // Arrange
+    let enabled = ({ page }: ComponentAvailabilityContext) =>
+      page.handle === 'freebies/essential'
+    let strictSchema: SchemaTypeStrict = {
+      title: 'Availability Test',
+      type: 'availability-test',
+      enabled,
+    }
+
+    // Act
+    let componentSchema = createSchemaTypeSafe(strictSchema)
+
+    // Assert
+    expect(componentSchema.enabled).toBe(enabled)
+  })
+
+  it('should_preserve_callback_when_registering_component_schema', () => {
+    // Arrange
+    let enabled = vi.fn(() => true)
+    let componentSchema: SchemaType = {
+      title: 'Availability Test',
+      type: 'availability-registration-test',
+      enabled,
+    }
+    let registry = new SchemaRegistry()
+
+    // Act
+    registry.register('availability-registration-test', componentSchema)
+    let registeredSchema = registry.get('availability-registration-test')
+
+    // Assert
+    expect({
+      enabled: registeredSchema?.enabled,
+      invocationCount: enabled.mock.calls.length,
+    }).toEqual({ enabled, invocationCount: 0 })
+  })
+
+  it('should_preserve_last_enabled_override_when_merging_schemas', () => {
+    // Arrange
+    let enabled = ({ page }: ComponentAvailabilityContext) =>
+      page.handle === 'freebies/essential'
+    let baseSchema: SchemaType = {
+      title: 'Availability Test',
+      type: 'availability-test',
+      enabled: true,
+    }
+
+    // Act
+    let disabledSchema = mergeSchemas(baseSchema, { enabled: false })
+    let callbackSchema = mergeSchemas(disabledSchema, { enabled })
+
+    // Assert
+    expect([disabledSchema.enabled, callbackSchema.enabled]).toEqual([
+      false,
+      enabled,
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- add `enabled?: boolean | Resolvable<boolean, ComponentAvailabilityContext>` to component schemas
- preserve callbacks through schema validation and Hydrogen registration for preview-side evaluation
- document callback context, synchronous behavior, and `enabledOn` AND semantics
- add schema and Hydrogen regression tests

Closes Weaverse/builder#2736

## Validation

- `pnpm run biome`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm -F @weaverse/schema build`
- `pnpm -F @weaverse/hydrogen build`
