### PR TITLE
Fix Next section preview bridge precedence

### DIFF
--- a/packages/next/__tests__/next-adapter.test.tsx
+++ b/packages/next/__tests__/next-adapter.test.tsx
@@ -994,6 +994,41 @@ describe('Studio runtime contract', () => {
     )
   })
 
+  it('should_resolve_preview_script_when_design_and_preview_modes_are_both_active', () => {
+    // Arrange — Builder section-preview URLs carry both flags; the preview
+    // iframe waits for `preview-size`, which only preview.js emits.
+    let searchParams = new URLSearchParams(
+      'isDesignMode=true&isPreviewMode=true&weaverseHost=https%3A%2F%2Fstudio.weaverse.io&weaverseVersion=2026.8.6'
+    )
+
+    // Act
+    let src = resolveWeaverseNextStudioScriptSrc(
+      { searchParams },
+      { storefrontHostname: 'shop.example' }
+    )
+
+    // Assert
+    expect(src).toBe(
+      'https://studio.weaverse.io/static/studio/next/preview.js?v=2026.8.6'
+    )
+  })
+
+  it('should_resolve_preview_script_when_design_mode_and_revision_preview_are_both_active', () => {
+    // Arrange
+    let searchParams = new URLSearchParams(
+      'isDesignMode=true&__revisionId=rev-1&weaverseHost=https%3A%2F%2Fstudio.weaverse.io'
+    )
+
+    // Act
+    let src = resolveWeaverseNextStudioScriptSrc(
+      { searchParams },
+      { storefrontHostname: 'shop.example' }
+    )
+
+    // Assert
+    expect(src).toBe('https://studio.weaverse.io/static/studio/next/preview.js')
+  })
+
   it('should_accept_studio_connect_without_framework_prop', () => {
     // Arrange
     let context = {

--- a/packages/next/__tests__/studio-connect.test.ts
+++ b/packages/next/__tests__/studio-connect.test.ts
@@ -121,6 +121,28 @@ describe('loadWeaverseNextStudioScript', () => {
     ).not.toThrow()
   })
 
+  it('should_load_preview_bundle_when_design_and_preview_modes_are_both_active', () => {
+    // Arrange — Builder section-preview URLs send both flags together; the
+    // preview iframe waits for `preview-size`, emitted only by preview.js.
+    let { appended, document } = createDocumentStub()
+    vi.stubGlobal('document', document)
+    let context: WeaverseNextRequestContext = {
+      searchParams: new URLSearchParams(
+        'isDesignMode=true&isPreviewMode=true&weaverseHost=https%3A%2F%2Fstudio.weaverse.io&weaverseVersion=section-preview-test'
+      ),
+    }
+
+    // Act
+    loadWeaverseNextStudioScript(context, {
+      storefrontHostname: 'shop.example',
+    })
+
+    // Assert
+    expect(appended[0]?.src).toBe(
+      'https://studio.weaverse.io/static/studio/next/preview.js?v=section-preview-test'
+    )
+  })
+
   it('should_not_append_script_for_untrusted_weaverse_host', () => {
     // Arrange
     let { appended, document } = createDocumentStub()

--- a/packages/next/src/studio-script-src.ts
+++ b/packages/next/src/studio-script-src.ts
@@ -118,7 +118,10 @@ export function resolveWeaverseNextStudioScriptSrc(
     return null
   }
 
-  let bundle = isDesignMode ? 'index.js' : 'preview.js'
+  // Builder section-preview URLs carry both isDesignMode and isPreviewMode;
+  // the preview iframe waits for `preview-size`, which only preview.js emits,
+  // so preview/revision mode takes precedence (matching Hydrogen).
+  let bundle = isPreviewMode || isRevisionPreview ? 'preview.js' : 'index.js'
   let version = last(searchParams, 'weaverseVersion')
   let url = `${origin}/static/studio/next/${bundle}`
   return version ? `${url}?v=${encodeURIComponent(version)}` : url


### PR DESCRIPTION
## Summary

- prefer the dedicated preview bridge when preview or revision mode is active, even when Builder also sends `isDesignMode=true`
- preserve the full Studio bridge for design-only requests
- cover the resolver and DOM script-loader paths for combined section-preview flags

## Verification

- `pnpm exec vp test --run __tests__/studio-connect.test.ts __tests__/next-adapter.test.tsx` — 88 passed
- `pnpm exec vp test --run` — 156 passed
- `pnpm exec tsc --noEmit`
- `pnpm exec biome check __tests__/studio-connect.test.ts __tests__/next-adapter.test.tsx src/studio-script-src.ts`
- `pnpm run build`
- `pnpm run package:check` — 8 packed packages and 10 TypeScript entrypoints verified

Closes Weaverse/weaverse#512

Refs Weaverse/builder#2739
Refs Weaverse/builder#2663
