### PR TITLE
chore(schema): regenerate API reports for translation inputs

### DIFF
--- a/api-reports/schema.api.md
+++ b/api-reports/schema.api.md
@@ -248,7 +248,22 @@ export const InputSchema: z.ZodUnion<readonly [z.ZodObject<{
 }, z.core.$loose>]>;
 
 // @public
-export type InputType = 'heading' | 'text' | 'richtext' | 'textarea' | 'url' | 'image' | 'video' | 'switch' | 'range' | 'select' | 'position' | 'product' | 'product-list' | 'collection' | 'collection-list' | 'blog' | 'metaobject' | 'color' | 'datepicker' | 'map-autocomplete' | 'toggle-group' | 'translation-key' | 'translation-image';
+export type InputType = 'heading' | 'text' | 'richtext' | 'textarea' | 'url' | 'image' | 'video' | 'switch' | 'range' | 'select' | 'position' | 'product' | 'product-list' | 'collection' | 'collection-list' | 'blog' | 'metaobject' | 'color' | 'datepicker' | 'map-autocomplete' | 'toggle-group'
+/**
+* Edits a translatable string in the theme's `i18n.staticContent`. Unlike
+* every other input, `name` is a dot-notation content key (`cart.title`), not
+* a component prop — the value is read back with `t('cart.title')` and is
+* stored per locale, so it never appears in theme settings or component data.
+* Intended for theme `settings`.
+*/
+| 'translation-key'
+/**
+* Same static content store as `translation-key`, but the value is an image
+* URL and Studio shows a media picker. Lets a merchant ship a different image
+* per locale; the theme reads it with the same `t()` lookup and feeds it to an
+* image component. Alt text is a separate `translation-key` input.
+*/
+| 'translation-image';
 
 // @public
 export const inputTypeSchema: z.ZodUnion<readonly [z.ZodLiteral<"heading">, z.ZodLiteral<"text">, z.ZodLiteral<"richtext">, z.ZodLiteral<"textarea">, z.ZodLiteral<"url">, z.ZodLiteral<"image">, z.ZodLiteral<"video">, z.ZodLiteral<"switch">, z.ZodLiteral<"range">, z.ZodLiteral<"select">, z.ZodLiteral<"position">, z.ZodLiteral<"product">, z.ZodLiteral<"product-list">, z.ZodLiteral<"collection">, z.ZodLiteral<"collection-list">, z.ZodLiteral<"blog">, z.ZodLiteral<"metaobject">, z.ZodLiteral<"color">, z.ZodLiteral<"datepicker">, z.ZodLiteral<"map-autocomplete">, z.ZodLiteral<"toggle-group">, z.ZodLiteral<"translation-key">, z.ZodLiteral<"translation-image">]>;

--- a/api-reports/schema.manifest.api.md
+++ b/api-reports/schema.manifest.api.md
@@ -186,7 +186,22 @@ export interface GenerateComponentManifestOptions {
 }
 
 // @public
-export type InputType = 'heading' | 'text' | 'richtext' | 'textarea' | 'url' | 'image' | 'video' | 'switch' | 'range' | 'select' | 'position' | 'product' | 'product-list' | 'collection' | 'collection-list' | 'blog' | 'metaobject' | 'color' | 'datepicker' | 'map-autocomplete' | 'toggle-group' | 'translation-key' | 'translation-image';
+export type InputType = 'heading' | 'text' | 'richtext' | 'textarea' | 'url' | 'image' | 'video' | 'switch' | 'range' | 'select' | 'position' | 'product' | 'product-list' | 'collection' | 'collection-list' | 'blog' | 'metaobject' | 'color' | 'datepicker' | 'map-autocomplete' | 'toggle-group'
+/**
+* Edits a translatable string in the theme's `i18n.staticContent`. Unlike
+* every other input, `name` is a dot-notation content key (`cart.title`), not
+* a component prop — the value is read back with `t('cart.title')` and is
+* stored per locale, so it never appears in theme settings or component data.
+* Intended for theme `settings`.
+*/
+| 'translation-key'
+/**
+* Same static content store as `translation-key`, but the value is an image
+* URL and Studio shows a media picker. Lets a merchant ship a different image
+* per locale; the theme reads it with the same `t()` lookup and feeds it to an
+* image component. Alt text is a separate `translation-key` input.
+*/
+| 'translation-image';
 
 // @public
 export type PageType = '*' | 'INDEX' | 'PRODUCT' | 'ALL_PRODUCTS' | 'COLLECTION' | 'COLLECTION_LIST' | 'PAGE' | 'BLOG' | 'ARTICLE' | 'CUSTOM';


### PR DESCRIPTION
## Summary

`📦 Public package API` has been failing on `main` since 2026-08-04. `20991fc9` ("feat: add translation-key and translation-image inputs for theme settings") added doc comments to the `InputType` union members without running `pnpm run api:report`, so the committed reports no longer match the extracted signature.

Regenerated output only. No source change, no behavior change.

## Verification

- `pnpm run package:check` → failed on `main` before, 6/6 passing after
- `pnpm run test` → 8/8 tasks
- `pnpm run typecheck` → 6/6 tasks
- `biome` → 147 files, clean
- `git status` → only the two `api-reports/` files touched