### PR TITLE
Fix the @weaverse scoped registry and move latest on Next prereleases

### DIFF
--- a/.claude/skills/releasing-weaverse-sdks/SKILL.md
+++ b/.claude/skills/releasing-weaverse-sdks/SKILL.md
@@ -16,7 +16,7 @@ Release ritual for the `@weaverse/*` npm packages monorepo. Covers version bump,
 - **Publish command:** `npm publish` (from individual package directories)
 - **Fixed version group:** core, react, hydrogen (always same version)
 - **Independent packages:** schema, cli, biome, i18n, next (each has own version)
-- **Next prereleases:** use exact prerelease versions, publish with npm dist-tag `alpha`, create `@weaverse/next@{VERSION}` tags and GitHub prereleases, and never move `latest`
+- **Next prereleases:** use exact prerelease versions, publish with npm dist-tag `alpha`, move `latest` to the version just published, and create `@weaverse/next@{VERSION}` tags and GitHub prereleases
 - **Never release:** remix (placeholder), shopify (archived)
 - **Tag format:** `v{VERSION}` for fixed group, `@weaverse/{pkg}@{VERSION}` for independents
 - **Internal deps use exact version pins** (e.g., `"@weaverse/core": "5.9.3"`)
@@ -68,7 +68,10 @@ A Next prerelease is version-only and does not use the bootstrap-publish orderin
    git commit -m "Release @weaverse/next $NEW_VERSION"
    git push origin main
    ```
-5. Publish with `npm publish --tag alpha`. Do not move `latest`.
+5. Publish with `npm publish --tag alpha`, then point `latest` at the same version:
+   ```bash
+   npm dist-tag add @weaverse/next@$NEW_VERSION latest
+   ```
 6. Create and push an annotated `@weaverse/next@$NEW_VERSION` tag, then create a GitHub prerelease from that tag.
 7. Verify npm dist-tags, the registry tarball/package version, tag target, GitHub prerelease metadata, and release CI.
 
@@ -188,9 +191,12 @@ For independent packages other than Next:
 cd packages/$PKG && npm publish && cd ../..
 ```
 
-For a Next prerelease, keep `latest` unchanged:
+For a Next prerelease, publish under `alpha` and move `latest` to it, so
+`npm i @weaverse/next` resolves to the newest release rather than a stale one:
 ```bash
-cd packages/next && npm publish --tag alpha && cd ../..
+cd packages/next && npm publish --tag alpha
+npm dist-tag add @weaverse/next@$NEW_VERSION latest
+cd ../..
 ```
 
 Verify each publish succeeds before continuing to the next. If one fails,

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-@weaverse:registry=https://registry.npmjs.com
+@weaverse:registry=https://registry.npmjs.org
 legacy-peer-deps=true
 # Don't auto re-install before each `pnpm run` — the root build pipeline
 # (turbo → per-package `pnpm run build`) would recurse infinitely otherwise.


### PR DESCRIPTION
Two release-tooling fixes found while publishing `@weaverse/next@0.1.0-alpha.17`.

## `.npmrc` scoped registry

`@weaverse:registry` pointed at `https://registry.npmjs.com` — `.com`, not `.org`. Reads redirect, so nothing looked wrong day to day, but writes do not carry the auth token across that redirect: `npm dist-tag add` failed with `401 Unauthorized - PUT https://registry.npmjs.com/...` even with a valid token and `--registry` set, because the scoped setting wins for scoped packages. The publish had to be driven with an explicit `--@weaverse:registry=https://registry.npmjs.org` override.

`pnpm-lock.yaml` contains no `registry.npmjs.com` references, so this needs no reinstall.

## `latest` on Next prereleases

The ritual said to never move `latest` for Next prereleases. In practice `latest` had been left on `0.1.0-alpha.0` while `alpha` advanced to `0.1.0-alpha.16`, so a plain `npm i @weaverse/next` installed a year-stale alpha — the tag was not protecting anyone from a prerelease, just serving an older one. The skill now moves `latest` to the version being published, which is what was done for `0.1.0-alpha.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)